### PR TITLE
Use const in more public API methods

### DIFF
--- a/include/freeradius-client.h
+++ b/include/freeradius-client.h
@@ -443,15 +443,15 @@ void rc_map2id_free(rc_handle *);
 
 /*	config.c		*/
 
-rc_handle *rc_read_config(char *);
-char *rc_conf_str(rc_handle *, char *);
-int rc_conf_int(rc_handle *, char *);
-SERVER *rc_conf_srv(rc_handle *, char *);
+rc_handle *rc_read_config(const char *);
+char *rc_conf_str(rc_handle *, const char *);
+int rc_conf_int(rc_handle *, const char *);
+SERVER *rc_conf_srv(rc_handle *, const char *);
 int rc_find_server(rc_handle *, char *, uint32_t *, char *);
 void rc_config_free(rc_handle *);
 int rc_add_config(rc_handle *, const char *, const char *, const char *, const int);
 rc_handle *rc_config_init(rc_handle *);
-int test_config(rc_handle *, char *);
+int test_config(rc_handle *, const char *);
 
 /*	dict.c			*/
 

--- a/lib/config.c
+++ b/lib/config.c
@@ -352,7 +352,7 @@ rc_config_init(rc_handle *rh)
  */
 
 rc_handle *
-rc_read_config(char *filename)
+rc_read_config(const char *filename)
 {
 	FILE *configfd;
 	char buffer[512], *p;
@@ -474,7 +474,7 @@ rc_read_config(char *filename)
  * Returns: config option value
  */
 
-char *rc_conf_str(rc_handle *rh, char *optname)
+char *rc_conf_str(rc_handle *rh, const char *optname)
 {
 	OPTION *option;
 
@@ -489,7 +489,7 @@ char *rc_conf_str(rc_handle *rh, char *optname)
 	}
 }
 
-int rc_conf_int(rc_handle *rh, char *optname)
+int rc_conf_int(rc_handle *rh, const char *optname)
 {
 	OPTION *option;
 
@@ -504,7 +504,7 @@ int rc_conf_int(rc_handle *rh, char *optname)
 	}
 }
 
-SERVER *rc_conf_srv(rc_handle *rh, char *optname)
+SERVER *rc_conf_srv(rc_handle *rh, const char *optname)
 {
 	OPTION *option;
 
@@ -527,7 +527,7 @@ SERVER *rc_conf_srv(rc_handle *rh, char *optname)
  * Returns: 0 on success, -1 when failure
  */
 
-int test_config(rc_handle *rh, char *filename)
+int test_config(rc_handle *rh, const char *filename)
 {
 #if 0
 	struct stat st;


### PR DESCRIPTION
This will eliminate compiler warnings in other projects that link against FreeRADIUS client, without breaking anything for anybody.
