### PR TITLE
Update freeradius-client.h

### DIFF
--- a/include/freeradius-client.h
+++ b/include/freeradius-client.h
@@ -18,9 +18,9 @@
 #define FREERADIUS_CLIENT_H
 
 #ifdef CP_DEBUG
-#define		DEBUG(args...)	rc_log(## args)
+#define		DEBUG(args, ...)	rc_log(## args)
 #else
-#define		DEBUG(args...)	;
+#define		DEBUG(args, ...)	;
 #endif
 
 #include	<sys/types.h>


### PR DESCRIPTION
Fix the following error when compiling freeradius mod_radius_cdr:
 error: ISO C does not permit named variadic macros [-Werror=variadic-macros]
