### PR TITLE
Fix handling of PW_TYPE_DATE

### DIFF
--- a/lib/avpair.c
+++ b/lib/avpair.c
@@ -280,6 +280,12 @@ rc_avpair_gen(rc_handle const *rh, VALUE_PAIR *pair, unsigned char *ptr,
 		memcpy((char *)&lvalue, (char *)ptr, 4);
 		pair->lvalue = ntohl(lvalue);
 		break;
+	case PW_TYPE_DATE:
+		if (attrlen != 4) {
+			rc_log(LOG_ERR, "rc_avpair_gen: received DATE "
+			    "attribute with invalid length");
+			goto shithappens;
+		}
 
 	default:
 		rc_log(LOG_WARNING, "rc_avpair_gen: %s has unknown type",

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -151,6 +151,7 @@ static int rc_pack_list (VALUE_PAIR *vp, char *secret, AUTH_HDR *auth)
 
 		    case PW_TYPE_INTEGER:
 		    case PW_TYPE_IPADDR:
+		    case PW_TYPE_DATE:
 			*buf++ = sizeof (uint32_t) + 2;
 			if (vsa_length_ptr != NULL) *vsa_length_ptr += sizeof(uint32_t) + 2;
 			lvalue = htonl (vp->lvalue);


### PR DESCRIPTION
Value of type PW_TYPE_DATE produces just 1 byte output, length and data are missing, subsequent avp are misaligned.
