### PR TITLE
Updated license of NetBSD code.

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -15,13 +15,6 @@ are met:
 2. Redistributions in binary form must reproduce the above copyright
    notice, this list of conditions and the following disclaimer in the
    documentation and/or other materials provided with the distribution.
-3. All advertising materials mentioning features or use of this software
-   must display the following acknowledgement:
-       This product includes software developed by the NetBSD
-       Foundation, Inc. and its contributors.
-4. Neither the name of The NetBSD Foundation nor the names of its
-   contributors may be used to endorse or promote products derived
-   from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
 ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED


### PR DESCRIPTION
From: christos@zoulas.com (Christos Zoulas)
Date: Tue, 9 Dec 2014 13:49:12 -0500
To: Nikos Mavrogiannopoulos nmav@redhat.com

On Dec 9,  5:00pm, nmav@redhat.com (Nikos Mavrogiannopoulos) wrote:
-- Subject: relicense code used in freebsd-client

| Dear Christos,
|  The freeradius-client project uses code from the NetBSD foundation
| (possibly written from you) as can be seen in [0] and [1]. As I see that
| you have relicensed NetBSD under the 3-clause BSD license, would it be
| possible to get permission to relicense that freeradius code under the
| 3-clause BSD license?
|

This is I guess from:

http://nxr.netbsd.org/xref/src/tools/compat/fgetln.c

Which is now 2-clause. You are free to use that license for it.

christos
