### PR TITLE
Added the configure option --with-nettle

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -224,6 +224,26 @@ then
 	)
 fi
 
+AC_ARG_WITH([nettle], [AS_HELP_STRING([--with-nettle],
+	[use nettle for crypto @<:@default=no@:>@])],
+	[with_nettle=$withval],
+	[with_nettle=no])
+
+if test "$with_nettle" != no; then
+	PKG_CHECK_MODULES(NETTLE, [nettle >= 2.4], [use_nettle=yes], [use_nettle=no])
+
+	if test "$use_nettle" = yes;then
+		CRYPTO_CFLAGS="$NETTLE_CFLAGS"
+		CRYPTO_LIBS="$NETTLE_LIBS"
+		AC_DEFINE([HAVE_NETTLE], 1, [Define to 1 to use nettle for MD5.])
+	fi
+fi
+
+AM_CONDITIONAL(ENABLE_NETTLE, test "$use_nettle" = "yes")
+
+AC_SUBST(CRYPTO_CFLAGS, [$CRYPTO_CFLAGS])
+AC_SUBST(CRYPTO_LIBS, [$CRYPTO_LIBS])
+
 AC_MSG_CHECKING([for /dev/urandom])
 if test -c /dev/urandom
 then

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -13,13 +13,20 @@ AUTOMAKE_OPTIONS = foreign
 RC_LOG_FACILITY = @RC_LOG_FACILITY@
 LIBVERSION = @LIBVERSION@
 
-INCLUDES = -I$(srcdir) -I$(top_srcdir)/include -I$(top_builddir)
+AM_CPPFLAGS = -I$(srcdir) -I$(top_srcdir)/include -I$(top_builddir) $(CRYPTO_CFLAGS)
 DEFS = @DEFS@ -DRC_LOG_FACILITY=$(RC_LOG_FACILITY)
 
 CLEANFILES = *~
 
 lib_LTLIBRARIES =   libfreeradius-client.la
 libfreeradius_client_la_SOURCES = buildreq.c clientid.c env.c sendserver.c \
-	avpair.c config.c dict.c ip_util.c log.c md5.c util.c  \
-	options.h md5.h
+	avpair.c config.c dict.c ip_util.c log.c util.c  \
+	options.h rc-md5.h rc-md5.c
+
+if !ENABLE_NETTLE
+libfreeradius_client_la_SOURCES += md5.c md5.h
+endif
+
 libfreeradius_client_la_LDFLAGS = -version-info $(LIBVERSION)
+
+libfreeradius_client_la_LIBADD = $(CRYPTO_LIBS)

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -1,29 +1,4 @@
-/* MD5 message-digest algorithm */
-
-/* This file is licensed under the BSD License, but is largely derived from
- * public domain source code
- */
-
-/*
- *  FORCE MD5 TO USE OUR MD5 HEADER FILE!
- *
- *  If we don't do this, it might pick up the systems broken MD5.
- *  - Alan DeKok <aland@ox.org>
- */
 #include "md5.h"
-
-void rc_md5_calc(unsigned char *output, unsigned char const *input,
-		     size_t inputlen);
-
-void rc_md5_calc(unsigned char *output, unsigned char const *input,
-		     size_t inlen)
-{
-	MD5_CTX	context;
-
-	MD5Init(&context);
-	MD5Update(&context, input, inlen);
-	MD5Final(output, &context);
-}
 
 /*	The below was retrieved from
  *	http://www.openbsd.org/cgi-bin/cvsweb/~checkout~/src/sys/crypto/md5.c?rev=1.1

--- a/lib/md5.h
+++ b/lib/md5.h
@@ -11,6 +11,12 @@
 
 #include "config.h"
 
+#ifdef HAVE_NETTLE
+
+#include <nettle/md5-compat.h>
+
+#else
+
 #ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
 #endif
@@ -74,5 +80,7 @@ void	 MD5Transform(uint32_t [4], uint8_t const [MD5_BLOCK_LENGTH])
 /*		__attribute__((__bounded__(__minbytes__,1,4)))*/
 /*		__attribute__((__bounded__(__minbytes__,2,MD5_BLOCK_LENGTH)))*/;
 /* __END_DECLS */
+
+#endif /* HAVE_NETTLE */
 
 #endif /* _RCRAD_MD5_H */

--- a/lib/rc-md5.c
+++ b/lib/rc-md5.c
@@ -1,0 +1,24 @@
+/* MD5 message-digest algorithm */
+
+/* This file is licensed under the BSD License, but is largely derived from
+ * public domain source code
+ */
+
+/*
+ *  FORCE MD5 TO USE OUR MD5 HEADER FILE!
+ *
+ *  If we don't do this, it might pick up the systems broken MD5.
+ *  - Alan DeKok <aland@ox.org>
+ */
+#include "rc-md5.h"
+
+void rc_md5_calc(unsigned char *output, unsigned char const *input,
+		     size_t inlen)
+{
+	MD5_CTX	context;
+
+	MD5Init(&context);
+	MD5Update(&context, input, inlen);
+	MD5Final(output, &context);
+}
+

--- a/lib/rc-md5.h
+++ b/lib/rc-md5.h
@@ -1,0 +1,27 @@
+/*
+ * md5.h        Structures and prototypes for md5.
+ *
+ * Version:     $Id: md5.h,v 1.2 2007/06/21 18:07:24 cparker Exp $
+ * License:	BSD
+ *
+ */
+
+#ifndef _RC_MD5_H
+#define _RC_MD5_H
+
+#include "config.h"
+
+#ifdef HAVE_NETTLE
+
+#include <nettle/md5-compat.h>
+
+#else
+
+#include "md5.h"
+
+#endif /* HAVE_NETTLE */
+
+void rc_md5_calc(unsigned char *output, unsigned char const *input,
+		     size_t inputlen);
+
+#endif /* _RC_MD5_H */


### PR DESCRIPTION
That patch allows to use the nettle's MD5 implementation when available.
