### PR TITLE
Config file updates

### DIFF
--- a/lib/config.c
+++ b/lib/config.c
@@ -497,7 +497,12 @@ int rc_conf_int(rc_handle const *rh, char const *optname)
 	option = find_option(rh, optname, OT_INT|OT_AUO);
 
 	if (option != NULL) {
-		return *((int *)option->val);
+		if (option->val) {
+			return *((int *)option->val);
+		} else {
+			rc_log(LOG_ERR, "rc_conf_int: config option %s was not set", optname);
+			return 0;
+		}
 	} else {
 		rc_log(LOG_CRIT, "rc_conf_int: unkown config option requested: %s", optname);
 		abort();


### PR DESCRIPTION
This patch set makes unrecognised config options non-fatal errors, and prevents a crash when a numeric configuration option is not set.
