### PR TITLE
Support connections in IPv6 servers

### DIFF
--- a/etc/radiusclient.conf.in
+++ b/etc/radiusclient.conf.in
@@ -34,6 +34,8 @@ issue	@pkgsysconfdir@/issue
 # RADIUS listens separated by a colon from the hostname. if
 # no port is specified /etc/services is consulted of the radius
 # service. if this fails also a compiled in default is used.
+# For IPv6 addresses use the '[IPv6]:port:secret' format, or
+# simply '[IPv6]'.
 authserver 	localhost
 
 # RADIUS server to use for accouting requests. All that I

--- a/include/freeradius-client.h
+++ b/include/freeradius-client.h
@@ -34,6 +34,11 @@
 #include	<stdio.h>
 #include	<time.h>
 
+
+/* for struct addrinfo and sockaddr_storage */
+#include <sys/socket.h>
+#include <netdb.h>
+
 #undef __BEGIN_DECLS
 #undef __END_DECLS
 #ifdef __cplusplus
@@ -94,8 +99,9 @@ typedef struct pw_auth_hdr
 struct rc_conf
 {
 	struct _option		*config_options;
-	uint32_t 			this_host_ipaddr;
-	uint32_t			*this_host_bind_ipaddr;
+	struct sockaddr_storage	own_bind_addr;
+	unsigned		own_bind_addr_set;
+
 	struct map2id_s		*map2id_list;
 	struct dict_attr	*dictionary_attributes;
 	struct dict_value	*dictionary_values;
@@ -488,7 +494,6 @@ rc_handle *rc_read_config(char const *);
 char *rc_conf_str(rc_handle const *, char const *);
 int rc_conf_int(rc_handle const *, char const *);
 SERVER *rc_conf_srv(rc_handle const *, char const *);
-int rc_find_server(rc_handle const *, char const *, uint32_t *, char *);
 void rc_config_free(rc_handle *);
 int rc_add_config(rc_handle *, char const *, char const *, char const *, int);
 rc_handle *rc_config_init(rc_handle *);
@@ -507,17 +512,12 @@ void rc_dict_free(rc_handle *);
 
 /* ip_util.c */
 
-struct hostent *rc_gethostbyname(char const *);
-struct hostent *rc_gethostbyaddr(char const *, size_t, int);
-uint32_t rc_get_ipaddr(char const *);
+
 int rc_good_ipaddr(char const *);
-char const *rc_ip_hostname(uint32_t);
 unsigned short rc_getport(int);
 int rc_own_hostname(char *, int);
-uint32_t rc_own_ipaddress(rc_handle *);
-uint32_t rc_own_bind_ipaddress(rc_handle *);
 struct sockaddr;
-int rc_get_srcaddr(struct sockaddr *, struct sockaddr *);
+int rc_get_srcaddr(struct sockaddr *, const struct sockaddr *);
 
 
 /* log.c */
@@ -527,7 +527,7 @@ void rc_log(int, char const *, ...);
 
 /* sendserver.c */
 
-int rc_send_server(rc_handle *, SEND_DATA *, char *);
+int rc_send_server(rc_handle *, SEND_DATA *, char *, unsigned flags);
 
 /* util.c */
 

--- a/include/includes.h
+++ b/include/includes.h
@@ -14,6 +14,9 @@
  *
  */
 
+#ifndef RC_INCLUDES_H
+# define RC_INCLUDES_H
+
 #include "config.h"
 
 /* AIX requires this to be the first thing in the file.  */
@@ -180,3 +183,5 @@ int sigprocmask (int, sigset_t *, sigset_t *);
 /* rlib/lock.c */
 int do_lock_exclusive(FILE *);
 int do_unlock(FILE *);
+
+#endif

--- a/lib/avpair.c
+++ b/lib/avpair.c
@@ -588,7 +588,13 @@ int rc_avpair_parse (rc_handle const *rh, char const *buffer, VALUE_PAIR **first
 				break;
 
 			    case PW_TYPE_IPADDR:
-                                pair->lvalue = rc_get_ipaddr(valstr);
+			    	if (inet_pton(AF_INET, valstr, &pair->lvalue) == 0) {
+			    		rc_log(LOG_ERR, "rc_avpair_parse: invalid IPv4 address %s", valstr);
+			    		free(pair);
+			    		return -1;
+			    	}
+
+                                pair->lvalue = ntohl(pair->lvalue);
 				break;
 
 			    case PW_TYPE_IPV6ADDR:

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -382,8 +382,10 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 
 	for (;;)
 	{
-		sendto (sockfd, (char *) auth, (unsigned int) total_length, (int) 0,
-			SA(auth_addr->ai_addr), auth_addr->ai_addrlen);
+		if (sendto (sockfd, (char *) auth, (unsigned int) total_length, (int) 0,
+			SA(auth_addr->ai_addr), auth_addr->ai_addrlen) == -1) {
+			rc_log(LOG_ERR, "%s: socket: %s", __FUNCTION__, strerror(errno));
+		}
 
 		pfd.fd = sockfd;
 		pfd.events = POLLIN;

--- a/lib/util.c
+++ b/lib/util.c
@@ -263,8 +263,6 @@ void rc_destroy(rc_handle *rh)
 	rc_map2id_free(rh);
 	rc_dict_free(rh);
 	rc_config_free(rh);
-	if (rh->this_host_bind_ipaddr != NULL)
-		free(rh->this_host_bind_ipaddr);
 	free(rh);
 }
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -15,5 +15,35 @@ size_t rc_strlcpy(char *dst, char const *src, size_t siz);
 # define strlcpy rc_strlcpy
 #endif
 
+#include <includes.h>
+
+#if !defined(SA_LEN)
+#define SA_LEN(sa) \
+  (((sa)->sa_family == AF_INET) ? \
+    sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6))
+
+#define SS_LEN(sa) \
+  (((sa)->ss_family == AF_INET) ? \
+    sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6))
+#endif
+
+#define SA_GET_INADDR(sa) \
+  (((sa)->sa_family == AF_INET) ? \
+    ((void*)&(((struct sockaddr_in*)(sa))->sin_addr)) : ((void*)&(((struct sockaddr_in6*)(sa))->sin6_addr)))
+
+#define SA_GET_INLEN(sa) \
+  ((sa)->sa_family == AF_INET) ? \
+    sizeof(struct in_addr) : sizeof(struct in6_addr)
+
+int rc_find_server_addr(rc_handle const *, char const *, struct addrinfo **, char *, unsigned flags);
+
+/* flags to rc_getaddrinfo() */
+#define PW_AI_PASSIVE		1
+#define PW_AI_AUTH		(1<<1)
+#define PW_AI_ACCT		(1<<2)
+
+struct addrinfo *rc_getaddrinfo (char const *host, unsigned flags);
+void rc_own_bind_addr(rc_handle *rh, struct sockaddr_storage *lia);
+
 #endif /* UTIL_H */
 


### PR DESCRIPTION
This set of patches adds support for connections to IPv6 servers. To simplify the library all legacy IPv4-only functions were dropped.

Resolves #42