### PR TITLE
removed RSA's copyright; the codebase doesn't include any of its code

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -78,25 +78,3 @@ THAT OPERATION WILL BE UNINTERRUPTED OR ERROR FREE.  The Regents of the
 University of Michigan and Merit Network, Inc. shall not be liable for any
 special, indirect, incidental or consequential damages with respect to any
 claim by Licensee or any third party arising from use of the software.
-------------------------------------------------------------------------------
-Copyright (C) 1991-2, RSA Data Security, Inc. Created 1991. 
-All rights reserved.
-
-License to copy and use this software is granted provided that it
-is identified as the "RSA Data Security, Inc. MD5 Message-Digest
-Algorithm" in all material mentioning or referencing this software
-or this function.
-
-License is also granted to make and use derivative works provided
-that such works are identified as "derived from the RSA Data
-Security, Inc. MD5 Message-Digest Algorithm" in all material
-mentioning or referencing the derived work.
-
-RSA Data Security, Inc. makes no representations concerning either
-the merchantability of this software or the suitability of this
-software for any particular purpose. It is provided "as is"
-without express or implied warranty of any kind.
-
-These notices must be retained in any copies of any part of this
-documentation and/or software.
-------------------------------------------------------------------------------


### PR DESCRIPTION
The included md5.c is from Colin Plumb, and is public domain.