### PR TITLE
rc_avpair_tostr: fixed regression which did not terminate the output str...

### DIFF
--- a/lib/avpair.c
+++ b/lib/avpair.c
@@ -760,6 +760,10 @@ int rc_avpair_tostr (rc_handle const *rh, VALUE_PAIR *pair, char *name, int ln, 
 			}
 			ptr++;
 		}
+		if (lv > 0)
+			value[pos++] = 0;
+		else
+			value[pos-1] = 0;
 		break;
 
 	    case PW_TYPE_INTEGER:


### PR DESCRIPTION
...ings