### PR TITLE
Disable failover to next RADIUS server on REJECT_RC.

### DIFF
--- a/lib/buildreq.c
+++ b/lib/buildreq.c
@@ -116,7 +116,7 @@ int rc_aaa(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **r
 
 	skip_count = 0;
 	result = ERROR_RC;
-	for (i=0; (i < aaaserver->max) && (result != OK_RC) && (result != BADRESP_RC)
+	for (i=0; (i < aaaserver->max) && (result != OK_RC) && (result != REJECT_RC)
 	    ; i++, now = rc_getctime())
 	{
 		if (aaaserver->deadtime_ends[i] != -1 &&
@@ -140,11 +140,11 @@ int rc_aaa(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **r
 		if (result == TIMEOUT_RC && radius_deadtime > 0)
 			aaaserver->deadtime_ends[i] = start_time + (double)radius_deadtime;
 	}
-	if (result == OK_RC || result == BADRESP_RC || skip_count == 0)
+	if (result == OK_RC || result == REJECT_RC || skip_count == 0)
 		goto exit;
 
 	result = ERROR_RC;
-	for (i=0; (i < aaaserver->max) && (result != OK_RC) && (result != BADRESP_RC)
+	for (i=0; (i < aaaserver->max) && (result != OK_RC) && (result != REJECT_RC)
 	    ; i++)
 	{
 		if (aaaserver->deadtime_ends[i] == -1 ||


### PR DESCRIPTION
This is one of my old patches that did not get into upstream.
Discussion: http://lists.freeradius.org/pipermail/freeradius-devel/2010-April/005334.html