### PR TITLE
Added TCP Support

### DIFF
--- a/etc/radiusclient.conf.in
+++ b/etc/radiusclient.conf.in
@@ -87,6 +87,12 @@ radius_deadtime	0
 # local address from which radius packets have to be sent
 bindaddr *
 
+#Protocol Support
+#Use "TCP" for using TCP protocol and "UDP" for using UDP protocol for 
+#RADIUS Messages
+#Default is UDP
+radius_proto	UDP
+
 # LOCAL settings
 
 # program to execute for local login

--- a/lib/options.h
+++ b/lib/options.h
@@ -50,6 +50,7 @@ static OPTION config_options_default[] = {
 {"radius_retries",	OT_INT,	ST_UNDEF, NULL},
 {"radius_deadtime",	OT_INT, ST_UNDEF, NULL},
 {"bindaddr",		OT_STR, ST_UNDEF, NULL},
+{"radius_proto",	OT_STR, ST_UNDEF, NULL},
 /* local options */
 {"login_local",		OT_STR, ST_UNDEF, NULL},
 };

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -246,6 +246,7 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 	VALUE_PAIR 	*vp;
 	struct pollfd	pfd;
 	double		start_time, timeout;
+	char *radius_proto = NULL;
 
 	server_name = data->server;
 	if (server_name == NULL || server_name[0] == '\0')
@@ -296,7 +297,13 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 		}
 	}
 
-	sockfd = socket (our_sockaddr.ss_family, SOCK_DGRAM, 0);
+	/* Select the Transport protocol for RADIUS Messages based on the configuration */
+	radius_proto = rc_conf_str(rh, "radius_proto");
+	if(!(strcmp(radius_proto, "TCP")))
+		sockfd = socket (our_sockaddr.ss_family, SOCK_STREAM, 0);
+	else
+		sockfd = socket (our_sockaddr.ss_family, SOCK_DGRAM,0);
+
 	if (sockfd < 0)
 	{
 		memset (secret, '\0', sizeof (secret));
@@ -385,8 +392,17 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 
 	for (;;)
 	{
-		do {
-			result = sendto (sockfd, (char *) auth, (unsigned int)total_length, 
+        do {
+            if(!(strcmp(radius_proto, "TCP"))){
+                /* Transport Protocol is TCP */
+                if((connect(sockfd, SA(auth_addr->ai_addr), auth_addr->ai_addrlen)) != 0)
+                {
+                    rc_log(LOG_ERR, "%s: Connect Call Failed : %s", __FUNCTION__, strerror(errno));
+                    result = -1;
+                    break;
+                }                
+            }
+            result = sendto (sockfd, (char *) auth, (unsigned int)total_length, 
 				(int) 0, SA(auth_addr->ai_addr), auth_addr->ai_addrlen);
 		} while (result == -1 && errno == EINTR);
 		if (result == -1) {


### PR DESCRIPTION
Currently RADIUS Client supports only UDP. Hence, added the option of using TCP protocol too for RADIUS Messages. Also, Made the selection of Transport Protocol as a configurable option to User. By changing the corresponding opton in conf file, the User will be able to use either TCP or UDP. 