### PR TITLE
TCP protocol support

### DIFF
--- a/etc/radiusclient.conf.in
+++ b/etc/radiusclient.conf.in
@@ -87,6 +87,11 @@ radius_deadtime	0
 # local address from which radius packets have to be sent
 bindaddr *
 
+# Protocol Support
+# Use "TCP" for using TCP protocol and "UDP" for using UDP protocol
+# Default is UDP
+radius_proto	UDP
+
 # LOCAL settings
 
 # program to execute for local login

--- a/etc/radiusclient.conf.in
+++ b/etc/radiusclient.conf.in
@@ -96,5 +96,5 @@ login_local	/bin/login
 # Protocol Support
 # Use "TCP" for using TCP protocol and "UDP" for using UDP protocol
 # Default is UDP
-#radius_proto	UDP
+radius_proto	UDP
 

--- a/etc/radiusclient.conf.in
+++ b/etc/radiusclient.conf.in
@@ -87,13 +87,14 @@ radius_deadtime	0
 # local address from which radius packets have to be sent
 bindaddr *
 
-# Protocol Support
-# Use "TCP" for using TCP protocol and "UDP" for using UDP protocol
-# Default is UDP
-#radius_proto	UDP
-
 # LOCAL settings
 
 # program to execute for local login
 # it must support the -f flag for preauthenticated login
 login_local	/bin/login
+
+# Protocol Support
+# Use "TCP" for using TCP protocol and "UDP" for using UDP protocol
+# Default is UDP
+#radius_proto	UDP
+

--- a/etc/radiusclient.conf.in
+++ b/etc/radiusclient.conf.in
@@ -90,7 +90,7 @@ bindaddr *
 # Protocol Support
 # Use "TCP" for using TCP protocol and "UDP" for using UDP protocol
 # Default is UDP
-radius_proto	UDP
+#radius_proto	UDP
 
 # LOCAL settings
 

--- a/include/freeradius-client.h
+++ b/include/freeradius-client.h
@@ -33,6 +33,7 @@
 /* #include	<inttypes.h> */
 #include	<stdio.h>
 #include	<time.h>
+#include <stdbool.h>
 
 
 /* for struct addrinfo and sockaddr_storage */
@@ -430,6 +431,7 @@ typedef struct send_data /* Used to pass information to sendserver() function */
 	int            retries;
 	VALUE_PAIR     *send_pairs;     //!< More a/v pairs to send.
 	VALUE_PAIR     *receive_pairs;  //!< Where to place received a/v pairs.
+	bool           radius_proto;
 } SEND_DATA;
 
 #ifndef MIN

--- a/lib/buildreq.c
+++ b/lib/buildreq.c
@@ -12,6 +12,7 @@
 #include <includes.h>
 #include <freeradius-client.h>
 #include "util.h"
+#include <stdbool.h>
 
 /** Build a skeleton RADIUS request using information from the config file
  *
@@ -73,6 +74,7 @@ int rc_aaa(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **r
 	double		now = 0;
 	time_t		dtime;
 	unsigned	type;
+    char        *radius_proto = NULL;
 
 	if (request_type != PW_ACCOUNTING_REQUEST) {
 		aaaserver = rc_conf_srv(rh, "authserver");
@@ -84,6 +86,9 @@ int rc_aaa(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **r
 	if (aaaserver == NULL)
 		return ERROR_RC;
 
+    radius_proto = rc_conf_str(rh, "radius_proto");
+    if(radius_proto != NULL)
+        data.radius_proto = true;
 	data.send_pairs = send;
 	data.receive_pairs = NULL;
 

--- a/lib/options.h
+++ b/lib/options.h
@@ -50,7 +50,7 @@ static OPTION config_options_default[] = {
 {"radius_retries",	OT_INT,	ST_UNDEF, NULL},
 {"radius_deadtime",	OT_INT, ST_UNDEF, NULL},
 {"bindaddr",		OT_STR, ST_UNDEF, NULL},
-{"radius_proto",		OT_STR, ST_UNDEF, NULL},
+//{"radius_proto",		OT_STR, ST_UNDEF, NULL},
 /* local options */
 {"login_local",		OT_STR, ST_UNDEF, NULL},
 };

--- a/lib/options.h
+++ b/lib/options.h
@@ -50,6 +50,7 @@ static OPTION config_options_default[] = {
 {"radius_retries",	OT_INT,	ST_UNDEF, NULL},
 {"radius_deadtime",	OT_INT, ST_UNDEF, NULL},
 {"bindaddr",		OT_STR, ST_UNDEF, NULL},
+{"radius_proto",		OT_STR, ST_UNDEF, NULL},
 /* local options */
 {"login_local",		OT_STR, ST_UNDEF, NULL},
 };

--- a/lib/options.h
+++ b/lib/options.h
@@ -50,9 +50,9 @@ static OPTION config_options_default[] = {
 {"radius_retries",	OT_INT,	ST_UNDEF, NULL},
 {"radius_deadtime",	OT_INT, ST_UNDEF, NULL},
 {"bindaddr",		OT_STR, ST_UNDEF, NULL},
-//{"radius_proto",		OT_STR, ST_UNDEF, NULL},
 /* local options */
 {"login_local",		OT_STR, ST_UNDEF, NULL},
+{"radius_proto",		OT_STR, ST_UNDEF, NULL},
 };
 
 #define	NUM_OPTIONS	((sizeof(config_options_default))/(sizeof(config_options_default[0])))

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -299,11 +299,15 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 
 /* Select the Transport protocol for RADIUS Messages based on the configuration */
 	radius_proto = rc_conf_str(rh, "radius_proto");
+    printf("!!!!RADIUS PROTO NOT NULL!!!!");
+    if(radius_proto != NULL)
+        sockfd = socket (our_sockaddr.ss_family, SOCK_DGRAM, 0);
+#if 0
 	if((strcmp(radius_proto, "UDP")) == 0)
 		sockfd = socket (our_sockaddr.ss_family, SOCK_DGRAM, 0);
 	else
 		sockfd = socket (our_sockaddr.ss_family, SOCK_STREAM, 0);
-
+#endif
 	if (sockfd < 0)
 	{
 		memset (secret, '\0', sizeof (secret));

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -297,10 +297,13 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 		}
 	}
 
+		sockfd = socket (our_sockaddr.ss_family, SOCK_DGRAM, 0);
 /* Select the Transport protocol for RADIUS Messages based on the configuration */
-	radius_proto = rc_conf_str(rh, "radius_proto");
-    printf("!!!!RADIUS PROTO NOT NULL!!!!");
-    if(radius_proto != NULL)
+	if(data->radius_proto)
+    sockfd = socket (our_sockaddr.ss_family, SOCK_DGRAM, 0);
+//radius_proto = rc_conf_str(rh, "radius_proto");
+  //  printf("!!!!RADIUS PROTO NOT NULL!!!!");
+    //if(radius_proto != NULL)
         sockfd = socket (our_sockaddr.ss_family, SOCK_DGRAM, 0);
 #if 0
 	if((strcmp(radius_proto, "UDP")) == 0)

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -297,14 +297,12 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 		}
 	}
 
-#if 0
 /* Select the Transport protocol for RADIUS Messages based on the configuration */
 	radius_proto = rc_conf_str(rh, "radius_proto");
-	if((strcmp(radius_proto, "TCP")) == 0)
-		sockfd = socket (our_sockaddr.ss_family, SOCK_STREAM, 0);
-	else
-#endif
+	if((strcmp(radius_proto, "UDP")) == 0)
 		sockfd = socket (our_sockaddr.ss_family, SOCK_DGRAM, 0);
+	else
+		sockfd = socket (our_sockaddr.ss_family, SOCK_STREAM, 0);
 
 	if (sockfd < 0)
 	{

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -246,6 +246,7 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 	VALUE_PAIR 	*vp;
 	struct pollfd	pfd;
 	double		start_time, timeout;
+	char *radius_proto = NULL;
 
 	server_name = data->server;
 	if (server_name == NULL || server_name[0] == '\0')
@@ -296,7 +297,13 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 		}
 	}
 
-	sockfd = socket (our_sockaddr.ss_family, SOCK_DGRAM, 0);
+/* Select the Transport protocol for RADIUS Messages based on the configuration */
+	radius_proto = rc_conf_str(rh, "radius_proto");
+	if((strcmp(radius_proto, "TCP")) == 0)
+		sockfd = socket (our_sockaddr.ss_family, SOCK_STREAM, 0);
+	else
+		sockfd = socket (our_sockaddr.ss_family, SOCK_DGRAM, 0);
+
 	if (sockfd < 0)
 	{
 		memset (secret, '\0', sizeof (secret));
@@ -386,6 +393,16 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 	for (;;)
 	{
 		do {
+			if((strcmp(radius_proto, "TCP")) == 0)
+			{
+				/* Transport Protocol is TCP */
+				if((connect(sockfd, SA(auth_addr->ai_addr), auth_addr->ai_addrlen)) != 0)
+				{
+					rc_log(LOG_ERR, "%s: Connect Call Failed : %s", __FUNCTION__, strerror(errno));
+					result = -1;
+					break;
+				}
+			}
 			result = sendto (sockfd, (char *) auth, (unsigned int)total_length, 
 				(int) 0, SA(auth_addr->ai_addr), auth_addr->ai_addrlen);
 		} while (result == -1 && errno == EINTR);

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -297,11 +297,13 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 		}
 	}
 
+#if 0
 /* Select the Transport protocol for RADIUS Messages based on the configuration */
 	radius_proto = rc_conf_str(rh, "radius_proto");
 	if((strcmp(radius_proto, "TCP")) == 0)
 		sockfd = socket (our_sockaddr.ss_family, SOCK_STREAM, 0);
 	else
+#endif
 		sockfd = socket (our_sockaddr.ss_family, SOCK_DGRAM, 0);
 
 	if (sockfd < 0)
@@ -393,6 +395,7 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 	for (;;)
 	{
 		do {
+#if 0
 			if((strcmp(radius_proto, "TCP")) == 0)
 			{
 				/* Transport Protocol is TCP */
@@ -403,6 +406,7 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 					break;
 				}
 			}
+#endif
 			result = sendto (sockfd, (char *) auth, (unsigned int)total_length, 
 				(int) 0, SA(auth_addr->ai_addr), auth_addr->ai_addrlen);
 		} while (result == -1 && errno == EINTR);

--- a/src/radexample.c
+++ b/src/radexample.c
@@ -30,6 +30,7 @@ main (int argc, char **argv)
 	uint32_t		service;
 	char 		msg[PW_MAX_MSG_SIZE], username_realm[256];
 	char		*default_realm;
+    char *radius_proto = NULL;
 	rc_handle	*rh;
 
 	pname = (pname = strrchr(argv[0],'/'))?pname+1:argv[0];
@@ -43,6 +44,10 @@ main (int argc, char **argv)
 		return ERROR_RC;
 
 	default_realm = rc_conf_str(rh, "default_realm");
+	radius_proto = rc_conf_str(rh, "radius_proto");
+    printf("\n\rproto %s\n\r", radius_proto);
+    if((strcmp(radius_proto, "UDP")) == 0)
+    printf("\n\r!!! Its UDP Dude !!!!\n\r");
 
 	strncpy(username, rc_getstr (rh, "login: ",1), sizeof(username));
 	strncpy (passwd, rc_getstr(rh, "Password: ",0), sizeof (passwd));


### PR DESCRIPTION
Added changes to also use TCP as transport protocol for RADIUS Messages (Currently only UDP is used a default Transport protocol). 

Added it as a configurable option in configuration file.