### PR TITLE
TCP support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ compiler:
 before_script:
   - sudo apt-get update -qq
   - sudo apt-get install -qq cppcheck
-  - ./configure
-script: make
+  - sudo apt-get install freeradius
+  - sudo cp tests/docker/freeradius-users /etc/freeradius/users 
+  - sudo cp tests/docker/radius-clients.conf /etc/freeradius/clients.conf
+  - sudo sed -i 's|ipaddr = 0.0.0.0/0|ipaddr = 127.0.0.1|g' /etc/freeradius/clients.conf
+  - sudo sed -i 's|ipv6addr = ::|ipv6addr = ::1|g' /etc/freeradius/clients.conf
+  - sudo killall freeradius
+  - sudo /usr/sbin/freeradius -X >/dev/null 2>&1 &
+  - autoreconf -fvi && ./configure
+
+script: make && SERVER_IP=127.0.0.1 SERVER_IP6=127.0.0.1 make check
 after_script: cppcheck -q -Iinclude lib src

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ INCLUDES = -D_GNU_SOURCE
 ACLOCAL = @ACLOCAL@
 LTLIBOBJS = @LTLIBOBJS@
 
-SUBDIRS = include lib src etc man doc patches login.radius rpm
+SUBDIRS = include lib src etc man doc patches login.radius rpm tests
 EXTRA_DIST = BUGS CHANGES COPYRIGHT README.rst README.radexample
 
 CLEANFILES = *~

--- a/configure.in
+++ b/configure.in
@@ -354,6 +354,8 @@ Makefile
 include/Makefile lib/Makefile src/Makefile man/Makefile etc/Makefile
 doc/Makefile patches/Makefile
 login.radius/Makefile login.radius/migs/Makefile
+tests/Makefile
+tests/docker/Makefile
 rpm/Makefile
 debian/Makefile
 ])

--- a/etc/radiusclient.conf.in
+++ b/etc/radiusclient.conf.in
@@ -34,6 +34,8 @@ issue	@pkgsysconfdir@/issue
 # RADIUS listens separated by a colon from the hostname. if
 # no port is specified /etc/services is consulted of the radius
 # service. if this fails also a compiled in default is used.
+# For IPv6 addresses use the '[IPv6]:port:secret' format, or
+# simply '[IPv6]'.
 authserver 	localhost
 
 # RADIUS server to use for accouting requests. All that I

--- a/etc/radiusclient.conf.in
+++ b/etc/radiusclient.conf.in
@@ -87,6 +87,11 @@ radius_deadtime	0
 # local address from which radius packets have to be sent
 bindaddr *
 
+# Transport Protocol Support
+# Use "TCP" for using TCP protocol. For "UDP, no need to mention. 
+# Default is UDP and UDP will be used if "TCP" is not explicitly mentioned.
+radius_proto
+
 # LOCAL settings
 
 # program to execute for local login

--- a/include/freeradius-client.h
+++ b/include/freeradius-client.h
@@ -34,6 +34,11 @@
 #include	<stdio.h>
 #include	<time.h>
 
+
+/* for struct addrinfo and sockaddr_storage */
+#include <sys/socket.h>
+#include <netdb.h>
+
 #undef __BEGIN_DECLS
 #undef __END_DECLS
 #ifdef __cplusplus
@@ -94,8 +99,9 @@ typedef struct pw_auth_hdr
 struct rc_conf
 {
 	struct _option		*config_options;
-	uint32_t 			this_host_ipaddr;
-	uint32_t			*this_host_bind_ipaddr;
+	struct sockaddr_storage	own_bind_addr;
+	unsigned		own_bind_addr_set;
+
 	struct map2id_s		*map2id_list;
 	struct dict_attr	*dictionary_attributes;
 	struct dict_value	*dictionary_values;
@@ -488,7 +494,6 @@ rc_handle *rc_read_config(char const *);
 char *rc_conf_str(rc_handle const *, char const *);
 int rc_conf_int(rc_handle const *, char const *);
 SERVER *rc_conf_srv(rc_handle const *, char const *);
-int rc_find_server(rc_handle const *, char const *, uint32_t *, char *);
 void rc_config_free(rc_handle *);
 int rc_add_config(rc_handle *, char const *, char const *, char const *, int);
 rc_handle *rc_config_init(rc_handle *);
@@ -507,17 +512,12 @@ void rc_dict_free(rc_handle *);
 
 /* ip_util.c */
 
-struct hostent *rc_gethostbyname(char const *);
-struct hostent *rc_gethostbyaddr(char const *, size_t, int);
-uint32_t rc_get_ipaddr(char const *);
+
 int rc_good_ipaddr(char const *);
-char const *rc_ip_hostname(uint32_t);
 unsigned short rc_getport(int);
 int rc_own_hostname(char *, int);
-uint32_t rc_own_ipaddress(rc_handle *);
-uint32_t rc_own_bind_ipaddress(rc_handle *);
 struct sockaddr;
-int rc_get_srcaddr(struct sockaddr *, struct sockaddr *);
+int rc_get_srcaddr(struct sockaddr *, const struct sockaddr *);
 
 
 /* log.c */
@@ -527,7 +527,7 @@ void rc_log(int, char const *, ...);
 
 /* sendserver.c */
 
-int rc_send_server(rc_handle *, SEND_DATA *, char *);
+int rc_send_server(rc_handle *, SEND_DATA *, char *, unsigned flags);
 
 /* util.c */
 

--- a/include/freeradius-client.h
+++ b/include/freeradius-client.h
@@ -419,6 +419,10 @@ typedef struct value_pair
 #define TIMEOUT_RC	1
 #define REJECT_RC	2
 
+/* Transport Protocol Types */
+#define PROTO_TCP 1
+#define PROTO_UDP 2
+
 typedef struct send_data /* Used to pass information to sendserver() function */
 {
 	uint8_t        code;		//!< RADIUS packet code.
@@ -430,6 +434,7 @@ typedef struct send_data /* Used to pass information to sendserver() function */
 	int            retries;
 	VALUE_PAIR     *send_pairs;     //!< More a/v pairs to send.
 	VALUE_PAIR     *receive_pairs;  //!< Where to place received a/v pairs.
+	uint8_t        radius_proto;	//!< Transport protocol type. 
 } SEND_DATA;
 
 #ifndef MIN

--- a/include/includes.h
+++ b/include/includes.h
@@ -14,6 +14,9 @@
  *
  */
 
+#ifndef RC_INCLUDES_H
+# define RC_INCLUDES_H
+
 #include "config.h"
 
 /* AIX requires this to be the first thing in the file.  */
@@ -180,3 +183,5 @@ int sigprocmask (int, sigset_t *, sigset_t *);
 /* rlib/lock.c */
 int do_lock_exclusive(FILE *);
 int do_unlock(FILE *);
+
+#endif

--- a/lib/avpair.c
+++ b/lib/avpair.c
@@ -588,7 +588,13 @@ int rc_avpair_parse (rc_handle const *rh, char const *buffer, VALUE_PAIR **first
 				break;
 
 			    case PW_TYPE_IPADDR:
-                                pair->lvalue = rc_get_ipaddr(valstr);
+			    	if (inet_pton(AF_INET, valstr, &pair->lvalue) == 0) {
+			    		rc_log(LOG_ERR, "rc_avpair_parse: invalid IPv4 address %s", valstr);
+			    		free(pair);
+			    		return -1;
+			    	}
+
+                                pair->lvalue = ntohl(pair->lvalue);
 				break;
 
 			    case PW_TYPE_IPV6ADDR:

--- a/lib/avpair.c
+++ b/lib/avpair.c
@@ -760,6 +760,10 @@ int rc_avpair_tostr (rc_handle const *rh, VALUE_PAIR *pair, char *name, int ln, 
 			}
 			ptr++;
 		}
+		if (lv > 0)
+			value[pos++] = 0;
+		else
+			value[pos-1] = 0;
 		break;
 
 	    case PW_TYPE_INTEGER:

--- a/lib/buildreq.c
+++ b/lib/buildreq.c
@@ -116,7 +116,7 @@ int rc_aaa(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **r
 
 	skip_count = 0;
 	result = ERROR_RC;
-	for (i=0; (i < aaaserver->max) && (result != OK_RC) && (result != BADRESP_RC)
+	for (i=0; (i < aaaserver->max) && (result != OK_RC) && (result != REJECT_RC)
 	    ; i++, now = rc_getctime())
 	{
 		if (aaaserver->deadtime_ends[i] != -1 &&
@@ -140,11 +140,11 @@ int rc_aaa(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **r
 		if (result == TIMEOUT_RC && radius_deadtime > 0)
 			aaaserver->deadtime_ends[i] = start_time + (double)radius_deadtime;
 	}
-	if (result == OK_RC || result == BADRESP_RC || skip_count == 0)
+	if (result == OK_RC || result == REJECT_RC || skip_count == 0)
 		goto exit;
 
 	result = ERROR_RC;
-	for (i=0; (i < aaaserver->max) && (result != OK_RC) && (result != BADRESP_RC)
+	for (i=0; (i < aaaserver->max) && (result != OK_RC) && (result != REJECT_RC)
 	    ; i++)
 	{
 		if (aaaserver->deadtime_ends[i] == -1 ||

--- a/lib/buildreq.c
+++ b/lib/buildreq.c
@@ -73,6 +73,7 @@ int rc_aaa(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **r
 	double		now = 0;
 	time_t		dtime;
 	unsigned	type;
+	char *radius_proto = NULL;
 
 	if (request_type != PW_ACCOUNTING_REQUEST) {
 		aaaserver = rc_conf_srv(rh, "authserver");
@@ -83,6 +84,12 @@ int rc_aaa(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **r
 	}
 	if (aaaserver == NULL)
 		return ERROR_RC;
+
+	radius_proto = rc_conf_str(rh, "radius_proto");
+	if(NULL != radius_proto)
+		data.radius_proto = PROTO_TCP;
+	else
+		data.radius_proto = PROTO_UDP;
 
 	data.send_pairs = send;
 	data.receive_pairs = NULL;

--- a/lib/config.c
+++ b/lib/config.c
@@ -586,13 +586,17 @@ int test_config(rc_handle const *rh, char const *filename)
 	struct stat st;
 	char	    *file;
 #endif
+	SERVER *srv;
 
-	if (!(rc_conf_srv(rh, "authserver")->max))
+	srv = rc_conf_srv(rh, "authserver");
+	if (!srv || !srv->max)
 	{
 		rc_log(LOG_ERR,"%s: no authserver specified", filename);
 		return -1;
 	}
-	if (!(rc_conf_srv(rh, "acctserver")->max))
+
+	srv = rc_conf_srv(rh, "acctserver");
+	if (!srv || !srv->max)
 	{
 		rc_log(LOG_ERR,"%s: no acctserver specified", filename);
 		return -1;

--- a/lib/options.h
+++ b/lib/options.h
@@ -50,6 +50,7 @@ static OPTION config_options_default[] = {
 {"radius_retries",	OT_INT,	ST_UNDEF, NULL},
 {"radius_deadtime",	OT_INT, ST_UNDEF, NULL},
 {"bindaddr",		OT_STR, ST_UNDEF, NULL},
+{"radius_proto",	OT_STR, ST_UNDEF, NULL},
 /* local options */
 {"login_local",		OT_STR, ST_UNDEF, NULL},
 };

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -217,27 +217,30 @@ static void strappend(char *dest, unsigned max_size, int *pos, const char *src)
  * @param data a pointer to a #SEND_DATA structure
  * @param msg must be an array of %PW_MAX_MSG_SIZE or %NULL; will contain the concatenation of
  *	any %PW_REPLY_MESSAGE received.
+ * @param flags must be %AUTH or %ACCT
  * @return %OK_RC (0) on success, %TIMEOUT_RC on timeout %REJECT_RC on acess reject, or negative
  *	on failure as return value.
  */
-int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg)
+int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 {
 	int             sockfd;
-	struct sockaddr_in sinlocal;
-	struct sockaddr_in sinremote;
 	AUTH_HDR       *auth, *recv_auth;
-	uint32_t           auth_ipaddr, nas_ipaddr;
 	char           *server_name;	/* Name of server to query */
+	struct sockaddr_storage our_sockaddr;
+	struct addrinfo *auth_addr = NULL;
 	socklen_t       salen;
 	int             result = 0;
 	int             total_length;
 	int             length, pos;
 	int             retry_max;
-	size_t			secretlen;
+	unsigned	discover_local_ip;
+	size_t		secretlen;
 	char            secret[MAX_SECRET_LENGTH + 1];
 	unsigned char   vector[AUTH_VECTOR_LEN];
 	uint8_t          recv_buffer[BUFFER_LEN];
 	uint8_t          send_buffer[BUFFER_LEN];
+	char		our_addr_txt[50]; /* hold a text IP */
+	char		auth_addr_txt[50]; /* hold a text IP */
 	uint8_t		*attr;
 	int		retries;
 	VALUE_PAIR 	*vp;
@@ -252,7 +255,8 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg)
 	    (vp->lvalue == PW_ADMINISTRATIVE))
 	{
 		strcpy(secret, MGMT_POLL_SECRET);
-		if ((auth_ipaddr = rc_get_ipaddr(server_name)) == 0)
+		auth_addr = rc_getaddrinfo(server_name, flags==AUTH?PW_AI_AUTH:PW_AI_ACCT);
+		if (auth_addr == NULL)
 			return ERROR_RC;
 	}
 	else
@@ -265,7 +269,7 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg)
 		else
 		{
 		*/
-		if (rc_find_server (rh, server_name, &auth_ipaddr, secret) != 0)
+		if (rc_find_server_addr (rh, server_name, &auth_addr, secret, flags) != 0)
 		{
 			rc_log(LOG_ERR, "rc_send_server: unable to find server: %s", server_name);
 			return ERROR_RC;
@@ -273,50 +277,76 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg)
 		/*}*/
 	}
 
-	DEBUG(LOG_ERR, "DEBUG: rc_send_server: creating socket to: %s", server_name);
+	rc_own_bind_addr(rh, &our_sockaddr);
+	discover_local_ip = 0;
+	if (our_sockaddr.ss_family == AF_INET) {
+		if (((struct sockaddr_in*)(&our_sockaddr))->sin_addr.s_addr == INADDR_ANY) {
+			discover_local_ip = 1;
+		}
+	}
 
-	sockfd = socket (AF_INET, SOCK_DGRAM, 0);
+	DEBUG(LOG_ERR, "DEBUG: rc_send_server: creating socket to: %s", server_name);
+	if (discover_local_ip) {
+		result = rc_get_srcaddr(SA(&our_sockaddr), auth_addr->ai_addr);
+		if (result != 0) {
+			memset (secret, '\0', sizeof (secret));
+			rc_log(LOG_ERR, "rc_send_server: cannot figure our own address");
+			result = ERROR_RC;
+			goto cleanup;
+		}
+	}
+
+	sockfd = socket (our_sockaddr.ss_family, SOCK_DGRAM, 0);
 	if (sockfd < 0)
 	{
 		memset (secret, '\0', sizeof (secret));
 		rc_log(LOG_ERR, "rc_send_server: socket: %s", strerror(errno));
-		return ERROR_RC;
+		result = ERROR_RC;
+		goto cleanup;
 	}
 
-	memset((char *)&sinlocal, '\0', sizeof(sinlocal));
-	sinlocal.sin_family = AF_INET;
-	sinlocal.sin_addr.s_addr = htonl(rc_own_bind_ipaddress(rh));
-	sinlocal.sin_port = htons((unsigned short) 0);
-	if (bind(sockfd, SA(&sinlocal), sizeof(sinlocal)) < 0)
+	if (our_sockaddr.ss_family == AF_INET)
+		((struct sockaddr_in*)&our_sockaddr)->sin_port = 0;
+	else
+		((struct sockaddr_in6*)&our_sockaddr)->sin6_port = 0;
+
+	if (bind(sockfd, SA(&our_sockaddr), SS_LEN(&our_sockaddr)) < 0)
 	{
 		close (sockfd);
 		memset (secret, '\0', sizeof (secret));
 		rc_log(LOG_ERR, "rc_send_server: bind: %s: %s", server_name, strerror(errno));
-		return ERROR_RC;
+		result = ERROR_RC;
+		goto cleanup;
 	}
 
 	retry_max = data->retries;	/* Max. numbers to try for reply */
 	retries = 0;			/* Init retry cnt for blocking call */
 
-	memset ((char *)&sinremote, '\0', sizeof(sinremote));
-	sinremote.sin_family = AF_INET;
-	sinremote.sin_addr.s_addr = htonl (auth_ipaddr);
-	sinremote.sin_port = htons ((unsigned short) data->svc_port);
+	if (data->svc_port) {
+		if (our_sockaddr.ss_family == AF_INET)
+			((struct sockaddr_in*)auth_addr->ai_addr)->sin_port = htons ((unsigned short) data->svc_port);
+		else
+			((struct sockaddr_in6*)auth_addr->ai_addr)->sin6_port = htons ((unsigned short) data->svc_port);
+	}
 
 	/*
 	 * Fill in NAS-IP-Address (if needed)
 	 */
 	if (rc_avpair_get(data->send_pairs, PW_NAS_IP_ADDRESS, 0) == NULL) {
-		if (sinlocal.sin_addr.s_addr == htonl(INADDR_ANY)) {
-			if (rc_get_srcaddr(SA(&sinlocal), SA(&sinremote)) != 0) {
-				close (sockfd);
-				memset (secret, '\0', sizeof (secret));
-				return ERROR_RC;
-			}
+		if (our_sockaddr.ss_family == AF_INET) {
+			uint32_t ip;
+			ip = *((uint32_t*)(&((struct sockaddr_in*)&our_sockaddr)->sin_addr));
+			ip = ntohl(ip);
+
+			rc_avpair_add(rh, &(data->send_pairs), PW_NAS_IP_ADDRESS,
+			    &ip, 0, 0);
+		} else {
+			void *p;
+			p = &((struct sockaddr_in6*)&our_sockaddr)->sin6_addr;
+
+			rc_avpair_add(rh, &(data->send_pairs), PW_NAS_IPV6_ADDRESS,
+			    p, 0, 0);
 		}
-		nas_ipaddr = ntohl(sinlocal.sin_addr.s_addr);
-		rc_avpair_add(rh, &(data->send_pairs), PW_NAS_IP_ADDRESS,
-		    &nas_ipaddr, 0, 0);
 	}
 
 	/* Build a request */
@@ -346,14 +376,16 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg)
 		auth->length = htons ((unsigned short) total_length);
 	}
 
+	getnameinfo(SA(&our_sockaddr), SS_LEN(&our_sockaddr), NULL, 0, our_addr_txt, sizeof(our_addr_txt), NI_NUMERICHOST);
+	getnameinfo(auth_addr->ai_addr, auth_addr->ai_addrlen, NULL, 0, auth_addr_txt, sizeof(auth_addr_txt), NI_NUMERICHOST);
+
 	DEBUG(LOG_ERR, "DEBUG: local %s : 0, remote %s : %u\n", 
-		inet_ntoa(sinlocal.sin_addr),
-		inet_ntoa(sinremote.sin_addr), data->svc_port);
+	      our_addr_txt, auth_addr_txt, data->svc_port);
 
 	for (;;)
 	{
 		sendto (sockfd, (char *) auth, (unsigned int) total_length, (int) 0,
-			SA(&sinremote), sizeof (struct sockaddr_in));
+			SA(auth_addr->ai_addr), auth_addr->ai_addrlen);
 
 		pfd.fd = sockfd;
 		pfd.events = POLLIN;
@@ -370,7 +402,8 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg)
 			rc_log(LOG_ERR, "rc_send_server: poll: %s", strerror(errno));
 			memset (secret, '\0', sizeof (secret));
 			close (sockfd);
-			return ERROR_RC;
+			result = ERROR_RC;
+			goto cleanup;
 		}
 		if (result == 1 && (pfd.revents & POLLIN) != 0)
 			break;
@@ -382,17 +415,18 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg)
 		if (retries++ >= retry_max)
 		{
 			rc_log(LOG_ERR,
-				"rc_send_server: no reply from RADIUS server %s:%u, %s",
-				 rc_ip_hostname (auth_ipaddr), data->svc_port, inet_ntoa(sinremote.sin_addr));
+				"rc_send_server: no reply from RADIUS server %s:%u",
+				 auth_addr_txt, data->svc_port);
 			close (sockfd);
 			memset (secret, '\0', sizeof (secret));
-			return TIMEOUT_RC;
+			result = TIMEOUT_RC;
+			goto cleanup;
 		}
 	}
-	salen = sizeof(sinremote);
+	salen = auth_addr->ai_addrlen;
 	length = recvfrom (sockfd, (char *) recv_buffer,
 			   (int) sizeof (recv_buffer),
-			   (int) 0, SA(&sinremote), &salen);
+			   (int) 0, SA(auth_addr->ai_addr), &salen);
 
 	if (length <= 0)
 	{
@@ -400,7 +434,8 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg)
 			 data->svc_port, strerror(errno));
 		close (sockfd);
 		memset (secret, '\0', sizeof (secret));
-		return ERROR_RC;
+		result = ERROR_RC;
+		goto cleanup;
 	}
 
 	recv_auth = (AUTH_HDR *)recv_buffer;
@@ -410,7 +445,8 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg)
 		    server_name, data->svc_port);
 		close(sockfd);
 		memset(secret, '\0', sizeof(secret));
-		return ERROR_RC;
+		result = ERROR_RC;
+		goto cleanup;
 	}
 
 	/*
@@ -463,7 +499,9 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg)
 	close (sockfd);
 	memset (secret, '\0', sizeof (secret));
 
-	if (result != OK_RC) return result;
+	if (result != OK_RC) {
+		goto cleanup;
+	}
 
 	if (msg) {
 		*msg = '\0';
@@ -495,6 +533,10 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg)
 	{
 		result = BADRESP_RC;
 	}
+
+ cleanup:
+ 	if (auth_addr)
+ 		freeaddrinfo(auth_addr);
 
 	return result;
 }

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -385,8 +385,11 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 
 	for (;;)
 	{
-		if (sendto (sockfd, (char *) auth, (unsigned int) total_length, (int) 0,
-			SA(auth_addr->ai_addr), auth_addr->ai_addrlen) == -1) {
+		do {
+			result = sendto (sockfd, (char *) auth, (unsigned int)total_length, 
+				(int) 0, SA(auth_addr->ai_addr), auth_addr->ai_addrlen);
+		} while (result == -1 && errno == EINTR);
+		if (result == -1) {
 			rc_log(LOG_ERR, "%s: socket: %s", __FUNCTION__, strerror(errno));
 		}
 
@@ -427,9 +430,11 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 		}
 	}
 	salen = auth_addr->ai_addrlen;
-	length = recvfrom (sockfd, (char *) recv_buffer,
-			   (int) sizeof (recv_buffer),
-			   (int) 0, SA(auth_addr->ai_addr), &salen);
+	do {
+		length = recvfrom (sockfd, (char *) recv_buffer,
+				   (int) sizeof (recv_buffer),
+				   (int) 0, SA(auth_addr->ai_addr), &salen);
+	} while(length == -1 && errno == EINTR);
 
 	if (length <= 0)
 	{

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -296,7 +296,11 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 		}
 	}
 
-	sockfd = socket (our_sockaddr.ss_family, SOCK_DGRAM, 0);
+	if(PROTO_TCP == data->radius_proto)
+		sockfd = socket (our_sockaddr.ss_family, SOCK_STREAM, 0);
+	else
+		sockfd = socket (our_sockaddr.ss_family, SOCK_DGRAM, 0);
+
 	if (sockfd < 0)
 	{
 		memset (secret, '\0', sizeof (secret));
@@ -386,6 +390,14 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 	for (;;)
 	{
 		do {
+			if(PROTO_TCP == data->radius_proto) {
+				if((connect(sockfd, SA(auth_addr->ai_addr), auth_addr->ai_addrlen)) != 0)
+				{
+					rc_log(LOG_ERR, "%s: Connect Call Failed : %s", __FUNCTION__, strerror(errno));
+					result = -1;
+					break;
+				}
+			}
 			result = sendto (sockfd, (char *) auth, (unsigned int)total_length, 
 				(int) 0, SA(auth_addr->ai_addr), auth_addr->ai_addrlen);
 		} while (result == -1 && errno == EINTR);

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -332,7 +332,8 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 	/*
 	 * Fill in NAS-IP-Address (if needed)
 	 */
-	if (rc_avpair_get(data->send_pairs, PW_NAS_IP_ADDRESS, 0) == NULL) {
+	if (rc_avpair_get(data->send_pairs, PW_NAS_IP_ADDRESS, 0) == NULL &&
+	    rc_avpair_get(data->send_pairs, PW_NAS_IPV6_ADDRESS, 0) == NULL) {
 		if (our_sockaddr.ss_family == AF_INET) {
 			uint32_t ip;
 			ip = *((uint32_t*)(&((struct sockaddr_in*)&our_sockaddr)->sin_addr));

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -384,8 +384,10 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 
 	for (;;)
 	{
-		sendto (sockfd, (char *) auth, (unsigned int) total_length, (int) 0,
-			SA(auth_addr->ai_addr), auth_addr->ai_addrlen);
+		if (sendto (sockfd, (char *) auth, (unsigned int) total_length, (int) 0,
+			SA(auth_addr->ai_addr), auth_addr->ai_addrlen) == -1) {
+			rc_log(LOG_ERR, "%s: socket: %s", __FUNCTION__, strerror(errno));
+		}
 
 		pfd.fd = sockfd;
 		pfd.events = POLLIN;

--- a/lib/util.c
+++ b/lib/util.c
@@ -263,8 +263,6 @@ void rc_destroy(rc_handle *rh)
 	rc_map2id_free(rh);
 	rc_dict_free(rh);
 	rc_config_free(rh);
-	if (rh->this_host_bind_ipaddr != NULL)
-		free(rh->this_host_bind_ipaddr);
 	free(rh);
 }
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -15,5 +15,35 @@ size_t rc_strlcpy(char *dst, char const *src, size_t siz);
 # define strlcpy rc_strlcpy
 #endif
 
+#include <includes.h>
+
+#if !defined(SA_LEN)
+#define SA_LEN(sa) \
+  (((sa)->sa_family == AF_INET) ? \
+    sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6))
+
+#define SS_LEN(sa) \
+  (((sa)->ss_family == AF_INET) ? \
+    sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6))
+#endif
+
+#define SA_GET_INADDR(sa) \
+  (((sa)->sa_family == AF_INET) ? \
+    ((void*)&(((struct sockaddr_in*)(sa))->sin_addr)) : ((void*)&(((struct sockaddr_in6*)(sa))->sin6_addr)))
+
+#define SA_GET_INLEN(sa) \
+  ((sa)->sa_family == AF_INET) ? \
+    sizeof(struct in_addr) : sizeof(struct in6_addr)
+
+int rc_find_server_addr(rc_handle const *, char const *, struct addrinfo **, char *, unsigned flags);
+
+/* flags to rc_getaddrinfo() */
+#define PW_AI_PASSIVE		1
+#define PW_AI_AUTH		(1<<1)
+#define PW_AI_ACCT		(1<<2)
+
+struct addrinfo *rc_getaddrinfo (char const *host, unsigned flags);
+void rc_own_bind_addr(rc_handle *rh, struct sockaddr_storage *lia);
+
 #endif /* UTIL_H */
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,0 +1,15 @@
+# Copyright (C) 2014 Nikos Mavrogiannopoulos
+#
+# License: BSD
+
+SUBDIRS = docker
+EXTRA_DIST = radiusclient-ipv6.conf servers-ipv6 \
+	radiusclient.conf servers README
+
+nodist_check_SCRIPTS = basic-tests.sh ipv6-tests.sh
+TESTS = basic-tests.sh ipv6-tests.sh
+
+TESTS_ENVIRONMENT = \
+	top_builddir="$(top_builddir)"                          \
+	srcdir="$(srcdir)"
+

--- a/tests/README
+++ b/tests/README
@@ -1,0 +1,9 @@
+====================
+How to run the tests
+====================
+
+sh run-server.sh #as root
+# The server IP is on the last line
+
+SERVER_IP=172.17.0.14 SERVER_IP6=172.17.0.14 make check
+

--- a/tests/basic-tests.sh
+++ b/tests/basic-tests.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# Copyright (C) 2014 Nikos Mavrogiannopoulos
+#
+# License: BSD
+
+srcdir="${srcdir:-.}"
+
+echo "***********************************************"
+echo "This test will use a radius server on localhost"
+echo "and which can be executed with run-server.sh   "
+echo "***********************************************"
+
+TMPFILE=tmp.out
+
+if test -z "$SERVER_IP";then
+	echo "the variable SERVER_IP is not defined"
+	exit 77
+fi
+
+sed 's/localhost/'$SERVER_IP'/g' <$srcdir/radiusclient.conf >radiusclient-temp.conf 
+sed 's/localhost/'$SERVER_IP'/g' <$srcdir/servers >servers-temp
+
+../src/radiusclient -f radiusclient-temp.conf  User-Name=test Password=test >$TMPFILE
+if test $? != 0;then
+	echo "Error in PAP auth"
+	exit 1
+fi
+
+grep "^Framed-Protocol                  = 'PPP'$" $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+	echo "Error in data received by server (Framed-Protocol)"
+	cat $TMPFILE
+	exit 1
+fi
+
+grep "^Framed-IP-Address                = '192.168.1.190'$" $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+	echo "Error in data received by server (Framed-IP-Address)"
+	cat $TMPFILE
+	exit 1
+fi
+
+grep "^Framed-Route                     = '192.168.100.5/24'$" $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+	echo "Error in data received by server (Framed-Route)"
+	cat $TMPFILE
+	exit 1
+fi
+
+rm -f servers-temp 
+rm -f $TMPFILE
+rm -f radiusclient-temp.conf
+
+exit 0

--- a/tests/docker/Dockerfile-radius
+++ b/tests/docker/Dockerfile-radius
@@ -1,0 +1,21 @@
+FROM fedora:21
+
+RUN yum install -y openssh-server
+RUN yum install -y freeradius
+RUN sed 's/PermitRootLogin without-password/PermitRootLogin yes/g' -i /etc/ssh/sshd_config
+
+RUN echo 'root:root' |chpasswd
+RUN useradd -m -d /home/admin -s /bin/bash admin
+RUN echo 'admin:admin' |chpasswd
+EXPOSE 1812
+EXPOSE 1812/udp
+EXPOSE 1813
+EXPOSE 1813/udp
+EXPOSE 22
+
+RUN mkdir /etc/ocserv
+
+ADD radius-clients.conf /etc/raddb/clients.conf
+ADD freeradius-users /etc/raddb/users
+
+CMD sshd-keygen;/usr/sbin/sshd;radiusd;sleep 360

--- a/tests/docker/Makefile.am
+++ b/tests/docker/Makefile.am
@@ -1,0 +1,1 @@
+EXTRA_DIST = Dockerfile-radius 	freeradius-users radius-clients.conf

--- a/tests/docker/freeradius-users
+++ b/tests/docker/freeradius-users
@@ -1,0 +1,26 @@
+#
+# This is a complete entry for "steve". Note that there is no Fall-Through
+# entry so that no DEFAULT entry will be used, and the user will NOT
+# get any attributes in addition to the ones listed here.
+#
+test	Cleartext-Password := "test"
+	Service-Type = Framed-User,
+	Framed-Protocol = PPP,
+	Framed-Route = 192.168.100.5/24,
+	Framed-Route = 192.168.1.0/8,
+	Framed-IP-Address = 192.168.1.190,
+	Framed-IP-Netmask = 255.255.255.0,
+	Framed-Routing = Broadcast-Listen,
+	Framed-MTU = 1500,
+
+test6	Cleartext-Password := "test"
+	Service-Type = Framed-User,
+	Framed-Protocol = PPP,
+	Framed-Route = 192.168.100.5/24,
+	Framed-Route = 192.168.1.0/8,
+	Framed-IPv6-Prefix = "2000:0:0:106::/64",
+	Framed-IP-Address = 192.168.1.190,
+	Framed-IP-Netmask = 255.255.255.0,
+	Framed-Routing = Broadcast-Listen,
+	Framed-MTU = 1500,
+

--- a/tests/docker/radius-clients.conf
+++ b/tests/docker/radius-clients.conf
@@ -1,0 +1,373 @@
+# -*- text -*-
+##
+## clients.conf -- client configuration directives
+##
+##	$Id: 729c15d3e84c6cdb54a5f3652d93a2d7f8725fd4 $
+
+#######################################################################
+#
+#  Define RADIUS clients (usually a NAS, Access Point, etc.).
+
+#
+#  Defines a RADIUS client.
+#
+#  '127.0.0.1' is another name for 'localhost'.  It is enabled by default,
+#  to allow testing of the server after an initial installation.  If you
+#  are not going to be permitting RADIUS queries from localhost, we suggest
+#  that you delete, or comment out, this entry.
+#
+#
+
+#
+#  Each client has a "short name" that is used to distinguish it from
+#  other clients.
+#
+#  In version 1.x, the string after the word "client" was the IP
+#  address of the client.  In 2.0, the IP address is configured via
+#  the "ipaddr" or "ipv6addr" fields.  For compatibility, the 1.x
+#  format is still accepted.
+#
+client localhost {
+	#  Allowed values are:
+	#	dotted quad (1.2.3.4)
+	#       hostname    (radius.example.com)
+	ipaddr = 0.0.0.0/0
+
+	#  OR, you can use an IPv6 address, but not both
+	#  at the same time.
+#	ipv6addr = ::	# any.  ::1 == localhost
+
+	#
+	#  A note on DNS:  We STRONGLY recommend using IP addresses
+	#  rather than host names.  Using host names means that the
+	#  server will do DNS lookups when it starts, making it
+	#  dependent on DNS.  i.e. If anything goes wrong with DNS,
+	#  the server won't start!
+	#
+	#  The server also looks up the IP address from DNS once, and
+	#  only once, when it starts.  If the DNS record is later
+	#  updated, the server WILL NOT see that update.
+	#
+
+	#  One client definition can be applied to an entire network.
+	#  e.g. 127/8 should be defined with "ipaddr = 127.0.0.0" and
+	#  "netmask = 8"
+	#
+	#  If not specified, the default netmask is 32 (i.e. /32)
+	#
+	#  We do NOT recommend using anything other than 32.  There
+	#  are usually other, better ways to achieve the same goal.
+	#  Using netmasks of other than 32 can cause security issues.
+	#
+	#  You can specify overlapping networks (127/8 and 127.0/16)
+	#  In that case, the smallest possible network will be used
+	#  as the "best match" for the client.
+	#
+	#  Clients can also be defined dynamically at run time, based
+	#  on any criteria.  e.g. SQL lookups, keying off of NAS-Identifier,
+	#  etc.
+	#  See raddb/sites-available/dynamic-clients for details.
+	#
+
+#	netmask = 32
+
+	#
+	#  The shared secret use to "encrypt" and "sign" packets between
+	#  the NAS and FreeRADIUS.  You MUST change this secret from the
+	#  default, otherwise it's not a secret any more!
+	#
+	#  The secret can be any string, up to 8k characters in length.
+	#
+	#  Control codes can be entered vi octal encoding,
+	#	e.g. "\101\102" == "AB"
+	#  Quotation marks can be entered by escaping them,
+	#	e.g. "foo\"bar"
+	#
+	#  A note on security:  The security of the RADIUS protocol
+	#  depends COMPLETELY on this secret!  We recommend using a
+	#  shared secret that is composed of:
+	#
+	#	upper case letters
+	#	lower case letters
+	#	numbers
+	#
+	#  And is at LEAST 8 characters long, preferably 16 characters in
+	#  length.  The secret MUST be random, and should not be words,
+	#  phrase, or anything else that is recognizable.
+	#
+	#  The default secret below is only for testing, and should
+	#  not be used in any real environment.
+	#
+	secret		= testing123
+
+	#
+	#  Old-style clients do not send a Message-Authenticator
+	#  in an Access-Request.  RFC 5080 suggests that all clients
+	#  SHOULD include it in an Access-Request.  The configuration
+	#  item below allows the server to require it.  If a client
+	#  is required to include a Message-Authenticator and it does
+	#  not, then the packet will be silently discarded.
+	#
+	#  allowed values: yes, no
+	require_message_authenticator = no
+
+	#
+	#  The short name is used as an alias for the fully qualified
+	#  domain name, or the IP address.
+	#
+	#  It is accepted for compatibility with 1.x, but it is no
+	#  longer necessary in 2.0
+	#
+#	shortname	= localhost
+
+	#
+	# the following three fields are optional, but may be used by
+	# checkrad.pl for simultaneous use checks
+	#
+
+	#
+	# The nastype tells 'checkrad.pl' which NAS-specific method to
+	#  use to query the NAS for simultaneous use.
+	#
+	#  Permitted NAS types are:
+	#
+	#	cisco
+	#	computone
+	#	livingston
+	#	juniper
+	#	max40xx
+	#	multitech
+	#	netserver
+	#	pathras
+	#	patton
+	#	portslave
+	#	tc
+	#	usrhiper
+	#	other		# for all other types
+
+	#
+	nas_type     = other	# localhost isn't usually a NAS...
+
+	#
+	#  The following two configurations are for future use.
+	#  The 'naspasswd' file is currently used to store the NAS
+	#  login name and password, which is used by checkrad.pl
+	#  when querying the NAS for simultaneous use.
+	#
+#	login       = !root
+#	password    = someadminpas
+
+	#
+	#  As of 2.0, clients can also be tied to a virtual server.
+	#  This is done by setting the "virtual_server" configuration
+	#  item, as in the example below.
+	#
+#	virtual_server = home1
+
+	#
+	#  A pointer to the "home_server_pool" OR a "home_server"
+	#  section that contains the CoA configuration for this
+	#  client.  For an example of a coa home server or pool,
+	#  see raddb/sites-available/originate-coa
+#	coa_server = coa
+}
+
+client localhost2 {
+	ipv6addr = ::
+
+	#
+	#  A note on DNS:  We STRONGLY recommend using IP addresses
+	#  rather than host names.  Using host names means that the
+	#  server will do DNS lookups when it starts, making it
+	#  dependent on DNS.  i.e. If anything goes wrong with DNS,
+	#  the server won't start!
+	#
+	#  The server also looks up the IP address from DNS once, and
+	#  only once, when it starts.  If the DNS record is later
+	#  updated, the server WILL NOT see that update.
+	#
+
+	#  One client definition can be applied to an entire network.
+	#  e.g. 127/8 should be defined with "ipaddr = 127.0.0.0" and
+	#  "netmask = 8"
+	#
+	#  If not specified, the default netmask is 32 (i.e. /32)
+	#
+	#  We do NOT recommend using anything other than 32.  There
+	#  are usually other, better ways to achieve the same goal.
+	#  Using netmasks of other than 32 can cause security issues.
+	#
+	#  You can specify overlapping networks (127/8 and 127.0/16)
+	#  In that case, the smallest possible network will be used
+	#  as the "best match" for the client.
+	#
+	#  Clients can also be defined dynamically at run time, based
+	#  on any criteria.  e.g. SQL lookups, keying off of NAS-Identifier,
+	#  etc.
+	#  See raddb/sites-available/dynamic-clients for details.
+	#
+
+#	netmask = 32
+
+	#
+	#  The shared secret use to "encrypt" and "sign" packets between
+	#  the NAS and FreeRADIUS.  You MUST change this secret from the
+	#  default, otherwise it's not a secret any more!
+	#
+	#  The secret can be any string, up to 8k characters in length.
+	#
+	#  Control codes can be entered vi octal encoding,
+	#	e.g. "\101\102" == "AB"
+	#  Quotation marks can be entered by escaping them,
+	#	e.g. "foo\"bar"
+	#
+	#  A note on security:  The security of the RADIUS protocol
+	#  depends COMPLETELY on this secret!  We recommend using a
+	#  shared secret that is composed of:
+	#
+	#	upper case letters
+	#	lower case letters
+	#	numbers
+	#
+	#  And is at LEAST 8 characters long, preferably 16 characters in
+	#  length.  The secret MUST be random, and should not be words,
+	#  phrase, or anything else that is recognizable.
+	#
+	#  The default secret below is only for testing, and should
+	#  not be used in any real environment.
+	#
+	secret		= testing123
+
+	#
+	#  Old-style clients do not send a Message-Authenticator
+	#  in an Access-Request.  RFC 5080 suggests that all clients
+	#  SHOULD include it in an Access-Request.  The configuration
+	#  item below allows the server to require it.  If a client
+	#  is required to include a Message-Authenticator and it does
+	#  not, then the packet will be silently discarded.
+	#
+	#  allowed values: yes, no
+	require_message_authenticator = no
+
+	#
+	#  The short name is used as an alias for the fully qualified
+	#  domain name, or the IP address.
+	#
+	#  It is accepted for compatibility with 1.x, but it is no
+	#  longer necessary in 2.0
+	#
+#	shortname	= localhost
+
+	#
+	# the following three fields are optional, but may be used by
+	# checkrad.pl for simultaneous use checks
+	#
+
+	#
+	# The nastype tells 'checkrad.pl' which NAS-specific method to
+	#  use to query the NAS for simultaneous use.
+	#
+	#  Permitted NAS types are:
+	#
+	#	cisco
+	#	computone
+	#	livingston
+	#	juniper
+	#	max40xx
+	#	multitech
+	#	netserver
+	#	pathras
+	#	patton
+	#	portslave
+	#	tc
+	#	usrhiper
+	#	other		# for all other types
+
+	#
+	nas_type     = other	# localhost isn't usually a NAS...
+
+	#
+	#  The following two configurations are for future use.
+	#  The 'naspasswd' file is currently used to store the NAS
+	#  login name and password, which is used by checkrad.pl
+	#  when querying the NAS for simultaneous use.
+	#
+#	login       = !root
+#	password    = someadminpas
+
+	#
+	#  As of 2.0, clients can also be tied to a virtual server.
+	#  This is done by setting the "virtual_server" configuration
+	#  item, as in the example below.
+	#
+#	virtual_server = home1
+
+	#
+	#  A pointer to the "home_server_pool" OR a "home_server"
+	#  section that contains the CoA configuration for this
+	#  client.  For an example of a coa home server or pool,
+	#  see raddb/sites-available/originate-coa
+#	coa_server = coa
+}
+
+# IPv6 Client
+#client ::1 {
+#	secret		= testing123
+#	shortname	= localhost
+#}
+#
+# All IPv6 Site-local clients
+#client fe80::/16 {
+#	secret		= testing123
+#	shortname	= localhost
+#}
+
+#client some.host.org {
+#	secret		= testing123
+#	shortname	= localhost
+#}
+
+#
+#  You can now specify one secret for a network of clients.
+#  When a client request comes in, the BEST match is chosen.
+#  i.e. The entry from the smallest possible network.
+#
+#client 192.168.0.0/24 {
+#	secret		= testing123-1
+#	shortname	= private-network-1
+#}
+#
+#client 192.168.0.0/16 {
+#	secret		= testing123-2
+#	shortname	= private-network-2
+#}
+
+
+#client 10.10.10.10 {
+#	# secret and password are mapped through the "secrets" file.
+#	secret      = testing123
+#	shortname   = liv1
+#       # the following three fields are optional, but may be used by
+#       # checkrad.pl for simultaneous usage checks
+#	nastype     = livingston
+#	login       = !root
+#	password    = someadminpas
+#}
+
+#######################################################################
+#
+#  Per-socket client lists.  The configuration entries are exactly
+#  the same as above, but they are nested inside of a section.
+#
+#  You can have as many per-socket client lists as you have "listen"
+#  sections, or you can re-use a list among multiple "listen" sections.
+#
+#  Un-comment this section, and edit a "listen" section to add:
+#  "clients = per_socket_clients".  That IP address/port combination
+#  will then accept ONLY the clients listed in this section.
+#
+#clients per_socket_clients {
+#	client 192.168.3.4 {
+#		secret = testing123
+#        }
+#}

--- a/tests/ipv6-tests.sh
+++ b/tests/ipv6-tests.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Copyright (C) 2014 Nikos Mavrogiannopoulos
+#
+# License: BSD
+
+srcdir="${srcdir:-.}"
+
+echo "***********************************************"
+echo "This test will use a radius server on localhost"
+echo "and which can be executed with run-server.sh   "
+echo "***********************************************"
+
+TMPFILE=tmp.out
+
+if test -z "$SERVER_IP6";then
+	echo "the variable SERVER_IP6 is not defined"
+	exit 77
+fi
+
+sed 's/::1/'$SERVER_IP6'/g' <$srcdir/radiusclient-ipv6.conf >radiusclient-temp.conf 
+sed 's/::1/'$SERVER_IP6'/g' <$srcdir/servers-ipv6 >servers-ipv6-temp
+
+../src/radiusclient -f radiusclient-temp.conf  User-Name=test6 Password=test >$TMPFILE
+if test $? != 0;then
+	echo "Error in PAP IPv6 auth"
+	exit 1
+fi
+
+grep "^Framed-IPv6-Prefix               = '2000:0:0:106::/64'$" $TMPFILE >/dev/null 2>&1
+if test $? != 0;then
+	echo "Error in data received by server (Framed-IPv6-Prefix)"
+	cat $TMPFILE
+	exit 1
+fi
+
+rm -f servers-temp 
+rm -f $TMPFILE
+rm -f radiusclient-temp.conf
+
+exit 0

--- a/tests/radiusclient-ipv6.conf
+++ b/tests/radiusclient-ipv6.conf
@@ -1,0 +1,89 @@
+# General settings
+
+# specify which authentication comes first respectively which
+# authentication is used. possible values are: "radius" and "local".
+# if you specify "radius,local" then the RADIUS server is asked
+# first then the local one. if only one keyword is specified only
+# this server is asked.
+auth_order	radius,local
+
+# maximum login tries a user has
+login_tries	4
+
+# timeout for all login tries
+# if this time is exceeded the user is kicked out
+login_timeout	60
+
+# name of the nologin file which when it exists disables logins.
+# it may be extended by the ttyname which will result in
+# a terminal specific lock (e.g. /etc/nologin.ttyS2 will disable
+# logins on /dev/ttyS2)
+nologin /etc/nologin
+
+# name of the issue file. it's only display when no username is passed
+# on the radlogin command line
+issue	/usr/local/etc/radiusclient/issue
+
+# RADIUS settings
+
+# RADIUS server to use for authentication requests. this config
+# item can appear more then one time. if multiple servers are
+# defined they are tried in a round robin fashion if one
+# server is not answering.
+# optionally you can specify a the port number on which is remote
+# RADIUS listens separated by a colon from the hostname. if
+# no port is specified /etc/services is consulted of the radius
+# service. if this fails also a compiled in default is used.
+authserver 	[::1]
+
+# RADIUS server to use for accouting requests. All that I
+# said for authserver applies, too. 
+#
+acctserver 	[::1]
+
+# file holding shared secrets used for the communication
+# between the RADIUS client and server
+servers		./servers-ipv6-temp
+
+# dictionary of allowed attributes and values
+# just like in the normal RADIUS distributions
+dictionary 	../etc/dictionary
+
+# file which specifies mapping between ttyname and NAS-Port attribute
+mapfile		../etc/port-id-map
+
+# default authentication realm to append to all usernames if no
+# realm was explicitly specified by the user
+# the radiusd directly form Livingston doesnt use any realms, so leave
+# it blank then
+default_realm
+
+# time to wait for a reply from the RADIUS server
+radius_timeout	10
+
+# resend request this many times before trying the next server
+radius_retries	3
+
+# The length of time in seconds that we skip a nonresponsive RADIUS
+# server for transaction requests.  Server(s) being in the "dead" state
+# are tried only after all other non-dead servers have been tried and
+# failed or timeouted.  The deadtime interval starts when the server
+# does not respond to an authentication/accounting request transmissions. 
+# When the interval expires, the "dead" server would be re-tried again,
+# and if it's still down then it will be considered "dead" for another
+# such interval and so on. This option is no-op if there is only one
+# server in the list. Set to 0 in order to disable the feature.
+radius_deadtime	0
+
+# local address from which radius packets have to be sent
+bindaddr *
+
+# file which holds sequence number for communication with the
+# RADIUS server
+seqfile		/var/run/radius.seq
+
+# LOCAL settings
+
+# program to execute for local login
+# it must support the -f flag for preauthenticated login
+login_local	/bin/login

--- a/tests/radiusclient.conf
+++ b/tests/radiusclient.conf
@@ -1,0 +1,89 @@
+# General settings
+
+# specify which authentication comes first respectively which
+# authentication is used. possible values are: "radius" and "local".
+# if you specify "radius,local" then the RADIUS server is asked
+# first then the local one. if only one keyword is specified only
+# this server is asked.
+auth_order	radius,local
+
+# maximum login tries a user has
+login_tries	4
+
+# timeout for all login tries
+# if this time is exceeded the user is kicked out
+login_timeout	60
+
+# name of the nologin file which when it exists disables logins.
+# it may be extended by the ttyname which will result in
+# a terminal specific lock (e.g. /etc/nologin.ttyS2 will disable
+# logins on /dev/ttyS2)
+nologin /etc/nologin
+
+# name of the issue file. it's only display when no username is passed
+# on the radlogin command line
+issue	/usr/local/etc/radiusclient/issue
+
+# RADIUS settings
+
+# RADIUS server to use for authentication requests. this config
+# item can appear more then one time. if multiple servers are
+# defined they are tried in a round robin fashion if one
+# server is not answering.
+# optionally you can specify a the port number on which is remote
+# RADIUS listens separated by a colon from the hostname. if
+# no port is specified /etc/services is consulted of the radius
+# service. if this fails also a compiled in default is used.
+authserver 	localhost
+
+# RADIUS server to use for accouting requests. All that I
+# said for authserver applies, too. 
+#
+acctserver 	localhost
+
+# file holding shared secrets used for the communication
+# between the RADIUS client and server
+servers		./servers-temp
+
+# dictionary of allowed attributes and values
+# just like in the normal RADIUS distributions
+dictionary 	../etc/dictionary
+
+# file which specifies mapping between ttyname and NAS-Port attribute
+mapfile		../etc/port-id-map
+
+# default authentication realm to append to all usernames if no
+# realm was explicitly specified by the user
+# the radiusd directly form Livingston doesnt use any realms, so leave
+# it blank then
+default_realm
+
+# time to wait for a reply from the RADIUS server
+radius_timeout	10
+
+# resend request this many times before trying the next server
+radius_retries	3
+
+# The length of time in seconds that we skip a nonresponsive RADIUS
+# server for transaction requests.  Server(s) being in the "dead" state
+# are tried only after all other non-dead servers have been tried and
+# failed or timeouted.  The deadtime interval starts when the server
+# does not respond to an authentication/accounting request transmissions. 
+# When the interval expires, the "dead" server would be re-tried again,
+# and if it's still down then it will be considered "dead" for another
+# such interval and so on. This option is no-op if there is only one
+# server in the list. Set to 0 in order to disable the feature.
+radius_deadtime	0
+
+# local address from which radius packets have to be sent
+bindaddr *
+
+# file which holds sequence number for communication with the
+# RADIUS server
+seqfile		/var/run/radius.seq
+
+# LOCAL settings
+
+# program to execute for local login
+# it must support the -f flag for preauthenticated login
+login_local	/bin/login

--- a/tests/run-server.sh
+++ b/tests/run-server.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+#
+# Copyright (C) 2015 Red Hat
+#
+#   Copyright (c) 2014 Red Hat, Inc.
+#   
+#   All rights reserved.
+#   
+#   Redistribution and use in source and binary forms, with or without
+#   modification, are permitted provided that the following conditions
+#   are met:
+#   1. Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#   2. Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#   
+#   THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+#   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#   ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+#   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+#   OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+#   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+#   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+#   OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+#   SUCH DAMAGE.
+
+srcdir=${srcdir:-.}
+
+#this test can only be run as root
+id|grep root >/dev/null 2>&1
+if [ $? != 0 ];then
+	exit 77
+fi
+
+CONFIG="radius"
+IMAGE=radius-test
+IMAGE_NAME=test_radius
+DOCKER_DIR=docker
+TMP=$IMAGE_NAME.tmp
+
+if test -x /usr/bin/docker;then
+DOCKER=/usr/bin/docker
+else
+DOCKER=/usr/bin/docker.io
+fi
+
+if ! test -x $DOCKER;then
+	echo "The docker program is needed to perform this test"
+	exit 77
+fi
+
+stop() {
+	$DOCKER stop $IMAGE_NAME
+	$DOCKER rm $IMAGE_NAME
+	exit 1
+}
+
+if test "$1" = "stop";then
+	stop
+fi
+
+$DOCKER stop $IMAGE_NAME >/dev/null 2>&1
+$DOCKER rm $IMAGE_NAME >/dev/null 2>&1
+
+rm -f $DOCKER_DIR/Dockerfile
+
+$DOCKER pull fedora:21
+if test $? != 0;then
+	echo "Cannot pull docker image"
+	$UNLOCKFILE
+	exit 1
+fi
+
+cp $DOCKER_DIR/Dockerfile-$CONFIG $DOCKER_DIR/Dockerfile
+
+if test ! -f $DOCKER_DIR/Dockerfile;then
+	echo "Cannot test in this system"
+	$UNLOCKFILE
+	exit 77
+fi
+
+echo "Creating image $IMAGE"
+$DOCKER build -t $IMAGE $DOCKER_DIR/
+if test $? != 0;then
+	echo "Cannot build docker image"
+	exit 1
+fi
+
+$DOCKER run -P --privileged=true --tty=false -d --name test_radius $IMAGE
+if test $? != 0;then
+	echo "Cannot run docker image"
+	exit 1
+fi
+
+IP=`$DOCKER inspect $IMAGE_NAME | grep IPAddress | cut -d '"' -f 4`
+if test -z "$IP";then
+	echo "Detected IP is null!"
+	stop
+fi
+echo "$IP"
+
+exit 0

--- a/tests/servers
+++ b/tests/servers
@@ -1,0 +1,3 @@
+## Server Name or Client/Server pair		Key		
+## ----------------				---------------
+localhost/localhost				testing123

--- a/tests/servers-ipv6
+++ b/tests/servers-ipv6
@@ -1,0 +1,3 @@
+## Server Name or Client/Server pair		Key		
+## ----------------				---------------
+::1				testing123


### PR DESCRIPTION
By Default, only UDP is used as transport protocol for RADIUS Messages in FreeRADIUS Client.

Since FreeRADIUS Server has started supporting TCP in latest releases, added TCP support to FreeRADIUS Client to utilize the feature.

Also, the choice of the transport protocol to be used for RADIUS messages is made configurable to user via the configuration file and all the existing interfaces of FreeRADIUS Client remain unchanged.