### PR TITLE
Compiler warnings

### DIFF
--- a/lib/avpair.c
+++ b/lib/avpair.c
@@ -790,7 +790,7 @@ int rc_avpair_tostr (rc_handle const *rh, VALUE_PAIR *pair, char *name, int ln, 
 
 	    case PW_TYPE_IPV6PREFIX: {
 	    	uint8_t ip[16];
-	    	uint8_t txt[48];
+	    	char txt[48];
 	    	if (pair->lvalue < 2)
 	    		return -1;
 

--- a/src/radius.c
+++ b/src/radius.c
@@ -29,6 +29,7 @@ LFUNC auth_radius(rc_handle *rh, uint32_t client_port, char const *username, cha
 	DICT_VALUE	*dval;
 
 	send = received = NULL;
+	memset(msg, 0, sizeof(msg));
 
 	/*
 	 * Determine and fill in Service-Type
@@ -188,7 +189,7 @@ LFUNC auth_radius(rc_handle *rh, uint32_t client_port, char const *username, cha
 		rc_log(LOG_NOTICE, "authentication OK, username %s, service %s%s%s",
 				username, service_str,(ftype_str)?"/":"", (ftype_str)?ftype_str:"");
 
-		if (msg && (*msg != '\0'))
+		if (*msg != '\0')
 			printf(SC_SERVER_REPLY, msg);
 		else
 			printf(SC_RADIUS_OK);
@@ -202,7 +203,7 @@ LFUNC auth_radius(rc_handle *rh, uint32_t client_port, char const *username, cha
 	{
 		rc_log(LOG_NOTICE, "authentication FAILED, type RADIUS, username %s",
 			   username_realm);
-		if (msg && (*msg != '\0'))
+		if (*msg != '\0')
 			printf(SC_SERVER_REPLY, msg);
 		else
 			printf(SC_RADIUS_FAILED);


### PR DESCRIPTION
Found them with clang-3.6, but recent versions of GCC would probably have found them as well.