### PR TITLE
rc_ipaddr_local should use a temporary sockaddr_storage

### DIFF
--- a/lib/config.c
+++ b/lib/config.c
@@ -20,6 +20,8 @@
 #include <options.h>
 #include "util.h"
 
+#define SA(p)	((struct sockaddr *)(p))
+
 /** Find an option in the option list
  *
  * @param rh a handle to parsed configuration.
@@ -683,7 +685,7 @@ static int find_match (const struct addrinfo* addr, const struct addrinfo *hostn
 static int rc_ipaddr_local(const struct sockaddr *addr)
 {
 	int temp_sock, res, serrno;
-	struct sockaddr tmpaddr;
+	struct sockaddr_storage tmpaddr;
 
 	memcpy(&tmpaddr, addr, SA_LEN(addr));
 
@@ -696,7 +698,7 @@ static int rc_ipaddr_local(const struct sockaddr *addr)
 	} else {
 		((struct sockaddr_in6*)&tmpaddr)->sin6_port = 0;
 	}
-	res = bind(temp_sock, &tmpaddr, SA_LEN(&tmpaddr));
+	res = bind(temp_sock, SA(&tmpaddr), SS_LEN(&tmpaddr));
 	serrno = errno;
 	close(temp_sock);
 	if (res == 0)


### PR DESCRIPTION
The code was written before the IPv6 support was added so it left a sockaddr (16 byte long) where a sockaddr_in (16 byte long) or a sockaddr_in6 (28 byte long) is copied using for the length the SA_LEN macro.
On my macOS localhost is resolved into IPv6 ::1 so a trivial test triggers a buffer overflow which was detected by the runtime.
The fix is trivial: just use a sockaddr_storage (as it was already done at other places in the code, for instance in sendserver.c).
