### PR TITLE
Calculate timeouts from monotonic time.

### DIFF
--- a/include/freeradius-client.h
+++ b/include/freeradius-client.h
@@ -530,7 +530,7 @@ char *rc_mksid(rc_handle *);
 rc_handle *rc_new(void);
 void rc_destroy(rc_handle *);
 char *rc_fgetln(FILE *, size_t *);
-double rc_getctime(void);
+double rc_getmtime(void);
 
 /* env.c */
 

--- a/lib/buildreq.c
+++ b/lib/buildreq.c
@@ -101,7 +101,7 @@ int rc_aaa(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **r
 		 * Fill in Acct-Delay-Time
 		 */
 		dtime = 0;
-		now = rc_getctime();
+		now = rc_getmtime();
 		adt_vp = rc_avpair_get(data.send_pairs, PW_ACCT_DELAY_TIME, 0);
 		if (adt_vp == NULL) {
 			adt_vp = rc_avpair_add(rh, &(data.send_pairs),
@@ -117,7 +117,7 @@ int rc_aaa(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **r
 	skip_count = 0;
 	result = ERROR_RC;
 	for (i=0; (i < aaaserver->max) && (result != OK_RC) && (result != REJECT_RC)
-	    ; i++, now = rc_getctime())
+	    ; i++, now = rc_getmtime())
 	{
 		if (aaaserver->deadtime_ends[i] != -1 &&
 		    aaaserver->deadtime_ends[i] > start_time) {
@@ -159,7 +159,7 @@ int rc_aaa(rc_handle *rh, uint32_t client_port, VALUE_PAIR *send, VALUE_PAIR **r
 		    aaaserver->port[i], aaaserver->secret[i], timeout, retries);
 
 		if (request_type == PW_ACCOUNTING_REQUEST) {
-			dtime = rc_getctime() - start_time;
+			dtime = rc_getmtime() - start_time;
 			rc_avpair_assign(adt_vp, &dtime, 0);
 		}
 

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -349,9 +349,9 @@ int rc_send_server (rc_handle *rh, SEND_DATA *data, char *msg, unsigned flags)
 		pfd.fd = sockfd;
 		pfd.events = POLLIN;
 		pfd.revents = 0;
-		start_time = rc_getctime();
+		start_time = rc_getmtime();
 		for (timeout = data->timeout; timeout > 0;
-		    timeout -= rc_getctime() - start_time) {
+		    timeout -= rc_getmtime() - start_time) {
 			result = poll(&pfd, 1, timeout * 1000);
 			if (result != -1 || errno != EINTR)
 				break;


### PR DESCRIPTION
Timeout calculations should always (where possible) be done using a monotonic
time source. This commit introduces that and discards the wall-clock time
approach.

This commit resolves #70