### PR TITLE
Support for programmatic secret and server specification

### DIFF
--- a/include/freeradius-client.h
+++ b/include/freeradius-client.h
@@ -518,7 +518,7 @@ void rc_log(int, char const *, ...);
 
 /* sendserver.c */
 
-int rc_send_server(rc_handle *, SEND_DATA *, char *, unsigned flags);
+int rc_send_server(rc_handle const*, SEND_DATA *, char *, unsigned flags);
 
 /* util.c */
 

--- a/lib/ip_util.c
+++ b/lib/ip_util.c
@@ -154,7 +154,7 @@ int rc_get_srcaddr(struct sockaddr *lia, const struct sockaddr *ria)
  * for sending requests in host order.
  *
  **/
-void rc_own_bind_addr(rc_handle *rh, struct sockaddr_storage *lia)
+void rc_own_bind_addr(rc_handle const *rh, struct sockaddr_storage *lia)
 {
 	char *txtaddr = rc_conf_str(rh, "bindaddr");
 	struct addrinfo *info;

--- a/lib/util.h
+++ b/lib/util.h
@@ -43,7 +43,7 @@ int rc_find_server_addr(rc_handle const *, char const *, struct addrinfo **, cha
 #define PW_AI_ACCT		(1<<2)
 
 struct addrinfo *rc_getaddrinfo (char const *host, unsigned flags);
-void rc_own_bind_addr(rc_handle *rh, struct sockaddr_storage *lia);
+void rc_own_bind_addr(rc_handle const *rh, struct sockaddr_storage *lia);
 
 #endif /* UTIL_H */
 


### PR DESCRIPTION
With this commit, a secret may be specified programmatically without
scanning the configuration files afterwards. This is useful in cases
where the whole RADIUS configuration is kept in memory without backing
it in said files.

Signed-off-by: Marcel Patzlaff <m.patzlaff@pilz.de>