### PR TITLE
Fix: initialise PRNG properly

### DIFF
--- a/lib/buildreq.c
+++ b/lib/buildreq.c
@@ -42,7 +42,7 @@ void rc_buildreq(rc_handle const *rh, SEND_DATA *data, int code, char *server, u
  */
 unsigned char rc_get_id()
 {
-	return (unsigned char)(random() & UCHAR_MAX);
+	return (unsigned char)(rc_random() & UCHAR_MAX);
 }
 
 /** Builds an authentication/accounting request for port id client_port with the value_pairs send and submits it to a server

--- a/lib/config.c
+++ b/lib/config.c
@@ -402,8 +402,6 @@ rc_handle *rc_read_config(char const *filename)
 	size_t pos;
 	rc_handle *rh;
 
-	srandom((unsigned int)(time(NULL)+getpid()));
-
 	rh = rc_new();
 	if (rh == NULL)
 		return NULL;

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -658,7 +658,7 @@ static void rc_random_vector (unsigned char *vector)
  fallback:
 	for (i = 0; i < AUTH_VECTOR_LEN;)
 	{
-		randno = random ();
+		randno = rc_random();
 		memcpy ((char *) vector, (char *) &randno, sizeof (int));
 		vector += sizeof (int);
 		i += sizeof (int);

--- a/lib/util.c
+++ b/lib/util.c
@@ -338,6 +338,23 @@ double rc_getmtime(void)
     return timespec.tv_sec + ((double)timespec.tv_nsec) / 1000000000.0;
 }
 
+/** Returns a pseudo-random number
+ * It ensures, that the PRNG is initialised properly.
+ *
+ * @return pseudo-random number
+ */
+long int rc_random(void)
+{
+	static int initialised = 0;
+	if (0 == initialised)
+	{
+		srandom((unsigned int)(time(NULL)+getpid()));
+		initialised = 1;
+	}
+
+	return random();
+}
+
 /*
  * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
  *
@@ -390,4 +407,3 @@ rc_strlcpy(char *dst, char const *src, size_t siz)
 }
 
 #endif
-

--- a/lib/util.h
+++ b/lib/util.h
@@ -45,5 +45,7 @@ int rc_find_server_addr(rc_handle const *, char const *, struct addrinfo **, cha
 struct addrinfo *rc_getaddrinfo (char const *host, unsigned flags);
 void rc_own_bind_addr(rc_handle const *rh, struct sockaddr_storage *lia);
 
+long int rc_random(void);
+
 #endif /* UTIL_H */
 


### PR DESCRIPTION
When configuring the library through rc_config_init, the PRNG is not
initalised. On platforms with no /dev/urandom this might be a serious
security issue because passwords are not properly protected anymore.

So this commit introduces a new utility function rc_random which
ensures, that the PRNG is initialised before the first call to
random.

This commit fixes #82

Signed-off-by: Marcel Patzlaff <m.patzlaff@pilz.de>