### PR TITLE
Updating the position of the null terminator in the case for the stri…

### DIFF
--- a/lib/avpair.c
+++ b/lib/avpair.c
@@ -770,10 +770,7 @@ int rc_avpair_tostr (rc_handle const *rh, VALUE_PAIR *pair, char *name, int ln, 
 			}
 			ptr++;
 		}
-		if (lv > 0)
-			value[pos++] = 0;
-		else
-			value[pos-1] = 0;
+		value[pos] = 0;
 		break;
 
 	    case PW_TYPE_INTEGER:


### PR DESCRIPTION
Updating the position of the null terminator in the case for the string data. In the existing code, the terminator is actually overwrites the last character when the value buffer length is exactly the size of the string data + 1.