### PR TITLE
Copies the vendor id for the attribute in the rc_avpair_parse()

### DIFF
--- a/lib/avpair.c
+++ b/lib/avpair.c
@@ -554,6 +554,7 @@ int rc_avpair_parse (rc_handle const *rh, char const *buffer, VALUE_PAIR **first
 			strcpy (pair->name, attr->name);
 			pair->attribute = attr->value;
 			pair->type = attr->type;
+			pair->vendor = attr->vendor;
 
 			switch (pair->type)
 			{


### PR DESCRIPTION
After commit 50d78bb53f4f341aa708e196b8955cacbae59669 `rc_avpair_parse()` was not copying the `vendor` attribute to the pair, thus any attribute parsed had a random vendor id (since vendor was undefined).

This PR should fix this