### PR TITLE
Fixes vendor attribute lookup

### DIFF
--- a/lib/dict.c
+++ b/lib/dict.c
@@ -385,9 +385,7 @@ DICT_ATTR *rc_dict_getattr(rc_handle const *rh, uint32_t attribute)
 	attr = rh->dictionary_attributes;
 	while (attr != NULL)
 	{
-		if (attr->vendor != vendor) continue;
-
-		if (attr->value == attribute)
+		if (attr->vendor == vendor && attr->value == attribute)
 		{
 			return attr;
 		}
@@ -410,9 +408,7 @@ DICT_ATTR *rc_dict_get_vendor_attr(rc_handle const *rh, uint32_t attribute, uint
 	attr = rh->dictionary_attributes;
 	while (attr != NULL)
 	{
-		if (attr->vendor != vendor) continue;
-
-		if (attr->value == attribute)
+		if (attr->vendor == vendor && attr->value == attribute)
 		{
 			return attr;
 		}


### PR DESCRIPTION
In methods `rc_dict_getattr()` and `rc_dict_get_vendor_attr()` if the vendor did not match, the loop continued without processing the next attribute, thus causing an endless loop when vendor specific attributes were used