### PR TITLE
Upper limit of the length of the shared secret

### DIFF
--- a/tests/docker/radius-clients.conf
+++ b/tests/docker/radius-clients.conf
@@ -76,7 +76,8 @@ client localhost {
 	#  the NAS and FreeRADIUS.  You MUST change this secret from the
 	#  default, otherwise it's not a secret any more!
 	#
-	#  The secret can be any string, up to 8k characters in length.
+	#  The secret can be any string, up to 256 characters in length.
+	#  Some RADIUS servers impose lower limits, 128 characters or less.
 	#
 	#  Control codes can be entered vi octal encoding,
 	#	e.g. "\101\102" == "AB"
@@ -214,7 +215,8 @@ client localhost2 {
 	#  the NAS and FreeRADIUS.  You MUST change this secret from the
 	#  default, otherwise it's not a secret any more!
 	#
-	#  The secret can be any string, up to 8k characters in length.
+	#  The secret can be any string, up to 256 characters in length.
+	#  Some RADIUS servers impose lower limits, 128 characters or less.
 	#
 	#  Control codes can be entered vi octal encoding,
 	#	e.g. "\101\102" == "AB"


### PR DESCRIPTION
* Properly document the client-side limit (currently 256 instead of 8192).
* Also refer to possibly lower server-side limits.

Fixes #120.