### PR TITLE
Fix vendor-specific attributes length validation

### DIFF
--- a/include/freeradius-client.h
+++ b/include/freeradius-client.h
@@ -53,6 +53,7 @@
 #define AUTH_PASS_LEN		(8 * 16) /* multiple of 16 */
 #define AUTH_ID_LEN		64
 #define AUTH_STRING_LEN		253	 /* maximum of 253 */
+#define VSA_HEADER_LEN		6	 /* vendor-specific attribute header: type(1) + length(1) + vendor-id(4) */
 
 #define BUFFER_LEN		8192
 

--- a/lib/avpair.c
+++ b/lib/avpair.c
@@ -60,7 +60,8 @@ int rc_avpair_assign (VALUE_PAIR *vp, void const *pval, int len)
 		case PW_TYPE_STRING:
 			if (len == -1)
 				len = (uint32_t)strlen((char const *)pval);
-			if (len > AUTH_STRING_LEN) {
+			int max_len = vp->vendor ? (AUTH_STRING_LEN - VSA_HEADER_LEN) : AUTH_STRING_LEN;
+			if (len > max_len) {
 		        	rc_log(LOG_ERR, "rc_avpair_assign: bad attribute length");
 		        	return -1;
 			}


### PR DESCRIPTION
Standard attributes can use full AUTH_STRING_LEN,
vendor-specific attributes need additional bytes for VSA header.

Otherwise, a malformed AVP will be created when VSA has value length between 247 and 253.