### PR TITLE
Use PATH_MAX for $INCLUDE path resolution

### DIFF
--- a/lib/dict.c
+++ b/lib/dict.c
@@ -256,6 +256,8 @@ int rc_read_dictionary (rc_handle *rh, char const *filename)
 		}
                 else if (strncmp (buffer, "$INCLUDE", 8) == 0)
                 {
+			char ifilename_buf[PATH_MAX];
+
 			/* Read the $INCLUDE line */
 			if (sscanf (buffer, "%63s%63s", dummystr, namestr) != 2)
 			{
@@ -270,10 +272,18 @@ int rc_read_dictionary (rc_handle *rh, char const *filename)
 			if (namestr[0] != '/') {
 				cp = strrchr(filename, '/');
 				if (cp != NULL) {
-					ifilename = alloca(AUTH_ID_LEN);
-					*cp = '\0';
-					snprintf(ifilename, AUTH_ID_LEN, "%s/%s", filename, namestr);
-					*cp = '/';
+					int n;
+					size_t dir_len = (size_t)(cp - filename);
+					n = snprintf(ifilename_buf, PATH_MAX, "%.*s/%s",
+						(int)dir_len, filename, namestr);
+					if (n < 0 || n >= PATH_MAX) {
+						rc_log(LOG_ERR,
+						 "rc_read_dictionary: $INCLUDE path too long (would be %d bytes, limit %d) on line %d of dictionary %s: %s",
+							 n, PATH_MAX, line_no, filename, namestr);
+						fclose(dictfd);
+						return -1;
+					}
+					ifilename = ifilename_buf;
 				}
 			}
 			if (rc_read_dictionary(rh, ifilename) < 0)


### PR DESCRIPTION
rc_read_dictionary() resolved relative $INCLUDE paths into a fixed 64-byte buffer (AUTH_ID_LEN). Since AUTH_ID_LEN is sized for attribute names, not file paths, a parent directory longer than ~60 characters caused snprintf to silently truncate the joined path; the recursive fopen() then failed with a misleading "couldn't open dictionary" error.

Size the buffer at PATH_MAX instead, and return an explicit error if the joined path would still exceed it rather than loading the wrong file.